### PR TITLE
[Feat] Review Entity 기능 구현 (3/3)

### DIFF
--- a/app/src/main/java/fc/be/app/domain/review/controller/ReviewController.java
+++ b/app/src/main/java/fc/be/app/domain/review/controller/ReviewController.java
@@ -1,13 +1,12 @@
 package fc.be.app.domain.review.controller;
 
-import fc.be.app.domain.review.dto.ReviewCreateRequest;
-import fc.be.app.domain.review.dto.ReviewCreateResponse;
-import fc.be.app.domain.review.dto.ReviewEditRequest;
-import fc.be.app.domain.review.dto.ReviewGetResponse;
+import fc.be.app.domain.review.dto.*;
 import fc.be.app.domain.review.service.ReviewService;
 import fc.be.app.global.http.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -28,18 +27,33 @@ public class ReviewController {
     }
 
     @DeleteMapping("/{reviewId}")
-    public ApiResponse<Void> deleteReview(@PathVariable Long reviewId) {
-        reviewService.deleteReview(reviewId);
-        return ApiResponse.ok();
+    public ApiResponse<Integer> deleteReview(@PathVariable Long reviewId) {
+        return ApiResponse.ok(reviewService.deleteReview(reviewId));
     }
 
-    @GetMapping("/{placeId}")
-    public ApiResponse<ReviewGetResponse> getPlaceReviews(@PathVariable Integer placeId) {
-        return ApiResponse.ok(reviewService.getPlaceReviews(placeId));
+    @GetMapping("/rating")
+    public ApiResponse<ReviewRatingResponse> getRatingAndReviewCount(
+            @Valid @RequestBody ReviewGetRequest reviewGetRequest
+    ) {
+        return ApiResponse.ok(reviewService.bringJsonReviewRatingAndCount(reviewGetRequest));
+    }
+
+    @GetMapping
+    public ApiResponse<ReviewGetResponse> getPlaceReviews(
+            @Valid @RequestBody ReviewGetRequest reviewGetRequest,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.ok(reviewService.bringJsonReviewInfo(reviewGetRequest,
+                PageRequest.of(page, size, Sort.by("visitedAt").descending())));
     }
 
     @GetMapping("/my")
-    public ApiResponse<ReviewGetResponse> getMemberReviews() {
-        return ApiResponse.ok(reviewService.getMemberReviews());
+    public ApiResponse<ReviewGetResponse> getMemberReviews(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        return ApiResponse.ok(reviewService.getMemberReviews(PageRequest.of(page, size,
+                Sort.by("visitedAt").descending())));
     }
 }

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewCreateRequest.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewCreateRequest.java
@@ -1,17 +1,18 @@
 package fc.be.app.domain.review.dto;
 
+
 import fc.be.app.domain.member.entity.Member;
 import fc.be.app.domain.place.Place;
-
 import fc.be.app.domain.review.entity.Review;
-
-import fc.be.openapi.tourapi.constant.ContentTypeId;
 import jakarta.validation.constraints.*;
+
 import java.time.LocalDate;
 import java.util.List;
 
+import static java.lang.Boolean.FALSE;
+
 public record ReviewCreateRequest(
-        @NotNull Integer placeId,
+        @Positive Integer placeId,
         @NotNull String thumbnail,
         @NotNull Integer contentTypeId,
         @NotNull String title,
@@ -31,6 +32,7 @@ public record ReviewCreateRequest(
                 .rating(rating)
                 .content(content)
                 .images(images)
+                .isGoogle(FALSE) //앱 내 리뷰이므로 기본 값 FALSE
                 .build();
     }
 }

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewCreateRequest.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewCreateRequest.java
@@ -13,11 +13,9 @@ import static java.lang.Boolean.FALSE;
 
 public record ReviewCreateRequest(
         @Positive Integer placeId,
-        @NotNull String thumbnail,
         @NotNull Integer contentTypeId,
         @NotNull String title,
-        @NotNull Integer areaCode,
-        @Min(1) Integer rating,
+        @Min(1) @Max(5) Integer rating,
         @NotBlank String content,
         List<String> images,
         @PastOrPresent LocalDate visitedAt

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewEditRequest.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewEditRequest.java
@@ -1,16 +1,13 @@
 package fc.be.app.domain.review.dto;
 
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.*;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public record ReviewEditRequest(
         @NotNull Long reviewId,
-        @Min(1) Integer rating,
+        @Min(1) @Max(5) Integer rating,
         @NotBlank String content,
         List<String> images,
         @PastOrPresent LocalDate visitedAt

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetMemberResponse.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetMemberResponse.java
@@ -31,7 +31,7 @@ public record ReviewGetMemberResponse(List<Item> reviews) {
         );
     }
 
-    public record Item(
+    private record Item(
             Long reviewId,
             String thumbnail,
             String placeTitle,

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetMemberResponse.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetMemberResponse.java
@@ -1,0 +1,45 @@
+package fc.be.app.domain.review.dto;
+
+import fc.be.app.domain.review.entity.Review;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+public record ReviewGetMemberResponse(List<Item> reviews) {
+
+    public static ReviewGetMemberResponse from(
+            List<Review> reviews
+    ) {
+        List<Item> items = new ArrayList<>();
+        for (var review : reviews) {
+            items.add(
+                    new Item(
+                            review.getId(),
+                            review.getPlace().getThumbnail(),
+                            review.getPlace().getTitle(),
+                            review.getPlace().getContentTypeId().getId(),
+                            review.getPlace().getLocation().getAreaCode(),
+                            review.getRating(),
+                            review.getVisitedAt(),
+                            review.getContent()
+                    )
+            );
+        }
+        return new ReviewGetMemberResponse(
+                items
+        );
+    }
+
+    public record Item(
+            Long reviewId,
+            String thumbnail,
+            String placeTitle,
+            Integer contentTypeId,
+            Integer areaCode,
+            Integer rating,
+            LocalDate visitedAt,
+            String content
+    ) {
+    }
+}

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetRequest.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetRequest.java
@@ -1,0 +1,10 @@
+package fc.be.app.domain.review.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewGetRequest(
+        @NotNull Integer placeId,
+        @NotNull Integer contentTypeId,
+        @NotNull String placeTitle
+) {
+}

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetRequest.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetRequest.java
@@ -1,10 +1,12 @@
 package fc.be.app.domain.review.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record ReviewGetRequest(
-        @NotNull Integer placeId,
+        @Positive Integer placeId,
         @NotNull Integer contentTypeId,
-        @NotNull String placeTitle
+        @NotBlank String placeTitle
 ) {
 }

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetResponse.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetResponse.java
@@ -23,7 +23,7 @@ public record ReviewGetResponse(
             items.add(
                     new Item(
                             review.getMember().getNickname(),
-                            review.getMember().getEmail(),// todo [Review] Member Filed 추가되면 작업 필요
+                            review.getMember().getProfile(),
                             review.getRating(),
                             review.getVisitedAt(),
                             review.getContent(),
@@ -45,7 +45,7 @@ public record ReviewGetResponse(
             items.add(
                     new Item(
                             review.nickname(),
-                            review.profileImage(),// todo [Review] Member Filed 추가되면 작업 필요
+                            review.profileImage(),
                             review.rating(),
                             TestchangeLocalDate(review.visitedAt()),
                             review.content(),
@@ -67,7 +67,7 @@ public record ReviewGetResponse(
                             .rating(review.rating())
                             .member(Member.builder()
                                     .nickname(review.authorAttribution().displayName())
-                                    .email(review.authorAttribution().photoUri())//todo [Review] 프로필사진 업데이트 요망
+                                    .profile(review.authorAttribution().photoUri())
                                     .build())
                             .visitedAt(changeLocalDate(review.publishTime()))
                             .isGoogle(Boolean.TRUE)
@@ -88,7 +88,7 @@ public record ReviewGetResponse(
                             .rating(review.rating())
                             .member(Member.builder()
                                     .nickname(review.nickname())
-                                    .email(review.profileImage())//todo [Review] 프로필사진 업데이트 요망
+                                    .profile(review.profileImage())
                                     .build())
                             .visitedAt(TestchangeLocalDate(review.visitedAt()))
                             .isGoogle(Boolean.TRUE)

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetResponse.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetResponse.java
@@ -36,28 +36,6 @@ public record ReviewGetResponse(
         );
     }
 
-    //todo 지워야함
-    public static ReviewGetResponse Testfrom(
-            GoogleTempReviewResponse googleTempReviewResponse
-    ) {
-        List<Item> items = new ArrayList<>();
-        for (var review : googleTempReviewResponse.reviews()) {
-            items.add(
-                    new Item(
-                            review.nickname(),
-                            review.profileImage(),
-                            review.rating(),
-                            TestchangeLocalDate(review.visitedAt()),
-                            review.content(),
-                            review.isGoogle()
-                    )
-            );
-        }
-        return new ReviewGetResponse(
-                items
-        );
-    }
-
     public static List<Review> convertToReviews(GoogleReviewResponse googleReviewResponse) {
         List<Review> reviews = new ArrayList<>();
         for (var review : googleReviewResponse.reviews()) {
@@ -79,7 +57,7 @@ public record ReviewGetResponse(
     }
 
     //todo 지워야함
-    public static List<Review> TestconvertToReviews(GoogleTempReviewResponse googleReviewResponse) {
+    public static List<Review> testConvertToReviews(GoogleTempReviewResponse googleReviewResponse) {
         List<Review> reviews = new ArrayList<>();
         for (var review : googleReviewResponse.reviews()) {
             reviews.add(
@@ -90,7 +68,7 @@ public record ReviewGetResponse(
                                     .nickname(review.nickname())
                                     .profile(review.profileImage())
                                     .build())
-                            .visitedAt(TestchangeLocalDate(review.visitedAt()))
+                            .visitedAt(testChangeLocalDate(review.visitedAt()))
                             .isGoogle(Boolean.TRUE)
                             .build()
             );
@@ -105,13 +83,12 @@ public record ReviewGetResponse(
         return localDateTime.toLocalDate();
     }
 
-    //todo 지워야함
-    private static LocalDate TestchangeLocalDate(String strLocalDateTime) {
+    private static LocalDate testChangeLocalDate(String strLocalDateTime) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         return LocalDate.parse(strLocalDateTime, formatter);
     }
 
-    public record Item(
+    private record Item(
             String nickname,
             String profileImage,
             Integer rating,

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetResponse.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewGetResponse.java
@@ -1,35 +1,123 @@
 package fc.be.app.domain.review.dto;
 
+import fc.be.app.domain.member.entity.Member;
 import fc.be.app.domain.review.entity.Review;
+import fc.be.openapi.google.dto.review.GoogleReviewResponse;
+import fc.be.openapi.google.dto.review.GoogleTempReviewResponse;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
-public record ReviewGetResponse(List<Item> reviews) {
+public record ReviewGetResponse(
+        List<Item> reviews
+) {
 
-    public static ReviewGetResponse from(List<Review> reviews) {
+    public static ReviewGetResponse from(
+            List<Review> reviews
+    ) {
         List<Item> items = new ArrayList<>();
-        for(var review : reviews){
+        for (var review : reviews) {
             items.add(
                     new Item(
                             review.getMember().getNickname(),
-                            null, // todo [Review] Member Filed 추가되면 작업 필요
+                            review.getMember().getEmail(),// todo [Review] Member Filed 추가되면 작업 필요
                             review.getRating(),
+                            review.getVisitedAt(),
                             review.getContent(),
                             review.getIsGoogle()
                     )
             );
         }
-        return new ReviewGetResponse(items);
+        return new ReviewGetResponse(
+                items
+        );
     }
 
-    private record Item(
+    //todo 지워야함
+    public static ReviewGetResponse Testfrom(
+            GoogleTempReviewResponse googleTempReviewResponse
+    ) {
+        List<Item> items = new ArrayList<>();
+        for (var review : googleTempReviewResponse.reviews()) {
+            items.add(
+                    new Item(
+                            review.nickname(),
+                            review.profileImage(),// todo [Review] Member Filed 추가되면 작업 필요
+                            review.rating(),
+                            TestchangeLocalDate(review.visitedAt()),
+                            review.content(),
+                            review.isGoogle()
+                    )
+            );
+        }
+        return new ReviewGetResponse(
+                items
+        );
+    }
+
+    public static List<Review> convertToReviews(GoogleReviewResponse googleReviewResponse) {
+        List<Review> reviews = new ArrayList<>();
+        for (var review : googleReviewResponse.reviews()) {
+            reviews.add(
+                    Review.builder()
+                            .content(review.originalText().text())
+                            .rating(review.rating())
+                            .member(Member.builder()
+                                    .nickname(review.authorAttribution().displayName())
+                                    .email(review.authorAttribution().photoUri())//todo [Review] 프로필사진 업데이트 요망
+                                    .build())
+                            .visitedAt(changeLocalDate(review.publishTime()))
+                            .isGoogle(Boolean.TRUE)
+                            .build()
+            );
+        }
+        reviews.sort((r1, r2) -> r2.getVisitedAt().compareTo(r1.getVisitedAt()));
+        return reviews;
+    }
+
+    //todo 지워야함
+    public static List<Review> TestconvertToReviews(GoogleTempReviewResponse googleReviewResponse) {
+        List<Review> reviews = new ArrayList<>();
+        for (var review : googleReviewResponse.reviews()) {
+            reviews.add(
+                    Review.builder()
+                            .content(review.content())
+                            .rating(review.rating())
+                            .member(Member.builder()
+                                    .nickname(review.nickname())
+                                    .email(review.profileImage())//todo [Review] 프로필사진 업데이트 요망
+                                    .build())
+                            .visitedAt(TestchangeLocalDate(review.visitedAt()))
+                            .isGoogle(Boolean.TRUE)
+                            .build()
+            );
+        }
+        reviews.sort((r1, r2) -> r2.getVisitedAt().compareTo(r1.getVisitedAt()));
+        return reviews;
+    }
+
+    private static LocalDate changeLocalDate(String strLocalDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME;
+        LocalDateTime localDateTime = LocalDateTime.parse(strLocalDateTime, formatter);
+        return localDateTime.toLocalDate();
+    }
+
+    //todo 지워야함
+    private static LocalDate TestchangeLocalDate(String strLocalDateTime) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return LocalDate.parse(strLocalDateTime, formatter);
+    }
+
+    public record Item(
             String nickname,
-            String profile,
+            String profileImage,
             Integer rating,
+            LocalDate visitedAt,
             String content,
             Boolean isGoogle
-    ){
-
+    ) {
     }
 }

--- a/app/src/main/java/fc/be/app/domain/review/dto/ReviewRatingResponse.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/ReviewRatingResponse.java
@@ -1,0 +1,7 @@
+package fc.be.app.domain.review.dto;
+
+public record ReviewRatingResponse(
+        Double rating,
+        Long userRatingCount
+) {
+}

--- a/app/src/main/java/fc/be/app/domain/review/exception/ReviewErrorCode.java
+++ b/app/src/main/java/fc/be/app/domain/review/exception/ReviewErrorCode.java
@@ -4,8 +4,7 @@ import lombok.Getter;
 
 @Getter
 public enum ReviewErrorCode {
-    REVIEW_NOT_FOUND(301, "review not found", "해당 리뷰가 존재하지 않습니다."),
-    CONTENT_TYPE_NOT_MATCH(302, "content type not match", "해당하는 콘텐츠 타입이 없습니다.")
+    REVIEW_NOT_FOUND(400, "review not found", "해당 리뷰가 존재하지 않습니다."),
     ;
     private final Integer responseCode;
     private final String title;

--- a/app/src/main/java/fc/be/app/domain/review/repository/ReviewRepository.java
+++ b/app/src/main/java/fc/be/app/domain/review/repository/ReviewRepository.java
@@ -1,13 +1,22 @@
 package fc.be.app.domain.review.repository;
 
 import fc.be.app.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    List<Review> findByPlaceId(Integer placeId);
+    Page<Review> findByMemberId(Long memberId, Pageable pageable);
 
-    List<Review> findByMemberId(Long memberId);
+    Page<Review> findByPlaceId(Integer placeId, Pageable pageable);
+
+    Integer deleteByIdAndMemberId(Long reviewId, Long memberId);
+
+    @Query("SELECT count(r), avg(r.rating) FROM Review r WHERE r.place.id = :placeId")
+    List<Number> countAndAverageRatingByPlaceId(@Param("placeId") Integer placeId);
 }

--- a/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
+++ b/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
@@ -120,7 +120,7 @@ public class ReviewService {
             var response = ReviewJsonReader.readReviewsJsonFile    //임시로 Json파일에서 읽어옴
                     ("./review-example/reviews/place_" + reviewGetRequest.contentTypeId() + ".json");
 
-            List<Review> reviews = new ArrayList<>(ReviewGetResponse.TestconvertToReviews(response));
+            List<Review> reviews = new ArrayList<>(ReviewGetResponse.testConvertToReviews(response));
             reviews.addAll(reviewRepository.findByPlaceId(placeId, pageable).toList());
             return ReviewGetResponse.from(reviews);
         }

--- a/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
+++ b/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
@@ -8,10 +8,17 @@ import fc.be.app.domain.review.entity.Review;
 import fc.be.app.domain.review.exception.ReviewErrorCode;
 import fc.be.app.domain.review.exception.ReviewException;
 import fc.be.app.domain.review.repository.ReviewRepository;
-import fc.be.app.global.http.ApiResponse;
+import fc.be.openapi.google.GooglePlacesService;
+import fc.be.openapi.google.ReviewJsonReader;
+import fc.be.openapi.google.dto.review.GoogleReviewResponse;
+import fc.be.openapi.google.dto.review.form.GoogleRatingResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,45 +26,127 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReviewService {
 
     private final ReviewRepository reviewRepository;
-    private final PlaceService placeService;
     private final MemberRepository memberRepository;
+    private final PlaceService placeService;
+    private final GooglePlacesService googlePlacesService;
 
     @Transactional
     public ReviewCreateResponse createReview(ReviewCreateRequest reviewCreateRequest) {
-        placeService.saveOrUpdatePlace(reviewCreateRequest.placeId(),
-                reviewCreateRequest.contentTypeId());
-
         //todo [Review] Security 적용 -1
-        Member member = memberRepository.save(Member.builder().build());
-        return ReviewCreateResponse.from(
-                reviewRepository.save(reviewCreateRequest.to(member)));
+        var member = memberRepository.save(memberRepository.save(Member.builder().build()));
+        Integer placeId = reviewCreateRequest.placeId();
+        Integer contentTypeId = reviewCreateRequest.contentTypeId();
+
+        placeService.saveOrUpdatePlace(placeId, contentTypeId);
+
+        return ReviewCreateResponse.from(reviewRepository.save(
+                reviewCreateRequest.to(member)));
     }
 
     @Transactional
-    public ApiResponse<ReviewEditResponse> editReview(ReviewEditRequest reviewEditRequest) {
+    public ReviewEditResponse editReview(ReviewEditRequest reviewEditRequest) {
         Review review = reviewRepository.findById(reviewEditRequest.reviewId())
                 .orElseThrow(() -> new ReviewException(ReviewErrorCode.REVIEW_NOT_FOUND));
 
         review.editReview(reviewEditRequest);
-        return ApiResponse.ok(ReviewEditResponse.from(reviewRepository.save(review)));
+        return ReviewEditResponse.from(reviewRepository.save(review));
+    }
+
+    public ReviewGetMemberResponse getMemberReviews(Pageable pageable) {
+        Long memberId = 1L;
+        // todo [Review] Security 적용 -2
+        return ReviewGetMemberResponse.from(
+                reviewRepository.findByMemberId(memberId, pageable).toList());
     }
 
     @Transactional
-    public void deleteReview(Long reviewId) {
-
-        reviewRepository.deleteById(reviewId);
+    public Integer deleteReview(Long reviewId) {
+        Long memberId = 1L;
+        return reviewRepository.deleteByIdAndMemberId(reviewId, memberId);
     }
 
-    public ApiResponse<ReviewGetResponse> getPlaceReviews(Integer placeId) {
-        return ApiResponse.ok(ReviewGetResponse.from(
-                reviewRepository.findByPlaceId(placeId)
-        ));
+    // 구글 API를 호출하는 실제 메서드
+    public ReviewGetResponse bringReviewInfo(ReviewGetRequest reviewGetRequest, Pageable pageable) {
+        Integer placeId = reviewGetRequest.placeId();
+
+        if (pageable.getPageNumber() == 0) {
+            GoogleReviewResponse response = googlePlacesService.bringGoogleReview(reviewGetRequest.placeTitle());
+            List<Review> reviews = new ArrayList<>(ReviewGetResponse.convertToReviews(response));
+
+            reviews.addAll(reviewRepository.findByPlaceId(placeId, pageable).toList());
+            return ReviewGetResponse.from(reviews);
+        }
+        return ReviewGetResponse.from(reviewRepository.findByPlaceId(placeId, pageable).toList());
     }
 
-    public ApiResponse<ReviewGetResponse> getMemberReviews() {
-        // todo [Review] Security 적용 -2
-        return ApiResponse.ok(ReviewGetResponse.from(
-                reviewRepository.findByMemberId(1L)
-        ));
+    // 구글 API를 호출하는 실제 메서드
+    public ReviewRatingResponse bringReviewRatingAndCount(ReviewGetRequest reviewGetRequest) {
+        GoogleRatingResponse googleReviewResponse = googlePlacesService.bringGoogleRatingCount(reviewGetRequest.placeTitle());
+        double googleRating = googleReviewResponse.rating();
+        long googleCount = googleReviewResponse.userRatingCount();
+
+        List<Number> tripVoteResponse = reviewRepository.countAndAverageRatingByPlaceId(reviewGetRequest.placeId());
+        double tripVoteRating = 0;
+        long tripVoteCount = 0;
+
+        if (!tripVoteResponse.isEmpty()) {
+            tripVoteRating = tripVoteResponse.getFirst().doubleValue();
+            tripVoteCount = tripVoteResponse.getLast().longValue();
+        }
+
+        long totalCount = googleCount + tripVoteCount;
+        double totalRating = 0;
+
+        if (totalCount != 0) {
+            totalRating = (googleRating * googleCount + tripVoteRating * tripVoteCount) / totalCount;
+        }
+
+        totalRating = Math.round(totalRating * 10) / 10.0;
+
+        return new ReviewRatingResponse(totalRating, totalCount);
+    }
+
+
+    //Json에서 구글 리뷰+별점을 가져오는 메서드
+    public ReviewGetResponse bringJsonReviewInfo(ReviewGetRequest reviewGetRequest, Pageable pageable) {
+        Integer placeId = reviewGetRequest.placeId();
+
+        if (pageable.getPageNumber() == 0) {
+            var response = ReviewJsonReader.readReviewsJsonFile    //임시로 Json파일에서 읽어옴
+                    ("./review-example/reviews/place_" + reviewGetRequest.contentTypeId() + ".json");
+
+            List<Review> reviews = new ArrayList<>(ReviewGetResponse.TestconvertToReviews(response));
+            reviews.addAll(reviewRepository.findByPlaceId(placeId, pageable).toList());
+            return ReviewGetResponse.from(reviews);
+        }
+        return ReviewGetResponse.from(reviewRepository.findByPlaceId(placeId, pageable).toList());
+    }
+
+    //Json에서 구글 리뷰+별점을 가져오는 메서드
+    public ReviewRatingResponse bringJsonReviewRatingAndCount(ReviewGetRequest reviewGetRequest) {
+        var googleReviewResponse = ReviewJsonReader.googleTempRatingResponse //임시로 Json파일에서 읽어옴
+                ("./review-example/rating/place_rating_" + reviewGetRequest.contentTypeId() + ".json");
+        double googleRating = googleReviewResponse.rating();
+        long googleCount = googleReviewResponse.userRatingCount();
+
+        List<Number> tripVoteResponse = reviewRepository.countAndAverageRatingByPlaceId(reviewGetRequest.placeId());
+        double tripVoteRating = 0;
+        long tripVoteCount = 0;
+
+        if (!tripVoteResponse.isEmpty()) {
+            tripVoteRating = tripVoteResponse.getFirst().doubleValue();
+            tripVoteCount = tripVoteResponse.getLast().longValue();
+        }
+
+        long totalCount = googleCount + tripVoteCount;
+        double totalRating = 0;
+
+        if (totalCount != 0) {
+            totalRating = (googleRating * googleCount + tripVoteRating * tripVoteCount) / totalCount;
+        }
+
+        totalRating = Math.round(totalRating * 10) / 10.0;
+
+        return new ReviewRatingResponse(totalRating, totalCount);
     }
 }

--- a/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
+++ b/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
@@ -1,6 +1,8 @@
 package fc.be.app.domain.review.service;
 
 import fc.be.app.domain.member.entity.Member;
+import fc.be.app.domain.member.exception.MemberErrorCode;
+import fc.be.app.domain.member.exception.MemberException;
 import fc.be.app.domain.member.repository.MemberRepository;
 import fc.be.app.domain.place.service.PlaceService;
 import fc.be.app.domain.review.dto.*;
@@ -33,9 +35,12 @@ public class ReviewService {
     @Transactional
     public ReviewCreateResponse createReview(ReviewCreateRequest reviewCreateRequest) {
         //todo [Review] Security 적용 -1
-        var member = memberRepository.save(memberRepository.save(Member.builder().build()));
+
         Integer placeId = reviewCreateRequest.placeId();
         Integer contentTypeId = reviewCreateRequest.contentTypeId();
+
+        Member member = memberRepository.findById(1L).orElseThrow(()->
+                new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
         placeService.saveOrUpdatePlace(placeId, contentTypeId);
 

--- a/app/src/test/java/fc/be/app/domain/space/service/SpaceServiceTest.java
+++ b/app/src/test/java/fc/be/app/domain/space/service/SpaceServiceTest.java
@@ -17,16 +17,23 @@ import fc.be.app.domain.space.repository.SpaceRepository;
 import fc.be.app.domain.space.vo.SpaceType;
 import java.time.LocalDate;
 import java.util.List;
+
+import fc.be.openapi.google.GooglePlacesService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("test")
 @SpringBootTest
 class SpaceServiceTest {
+
+    @MockBean
+    private GooglePlacesService placesService;
 
     @Autowired
     private SpaceService spaceService;

--- a/openapi/src/main/java/fc/be/openapi/google/ReviewJsonReader.java
+++ b/openapi/src/main/java/fc/be/openapi/google/ReviewJsonReader.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fc.be.openapi.google.dto.review.GoogleTempRatingResponse;
 import fc.be.openapi.google.dto.review.GoogleTempReviewResponse;
+import fc.be.openapi.tourapi.exception.TourAPIError;
+import fc.be.openapi.tourapi.exception.TourAPIErrorCode;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -22,7 +24,7 @@ public class ReviewJsonReader {
                 googleReviewResponse = objectMapper.readValue(inputStream, GoogleTempReviewResponse.class);
             }
         } catch (IOException e) {
-            log.error("Error reading JSON file: ", e);
+            new TourAPIError(TourAPIErrorCode.NO_CONTENTTPYEID);
         }
         return googleReviewResponse;
     }
@@ -35,7 +37,7 @@ public class ReviewJsonReader {
                 googleTempRatingResponse = objectMapper.readValue(inputStream, GoogleTempRatingResponse.class);
             }
         } catch (IOException e) {
-            log.error("Error reading JSON file: ", e);
+            new TourAPIError(TourAPIErrorCode.NO_CONTENTTPYEID);
         }
         return googleTempRatingResponse;
     }

--- a/openapi/src/test/http/review.http
+++ b/openapi/src/test/http/review.http
@@ -1,0 +1,67 @@
+## 구글 PlaceAPI - 검색 결과 아이템의 id를 받아 리뷰로 반환
+### 숙소
+GET http://localhost:8080/test/review?textQuery=서울 중구 동호로 249
+
+### 축제
+GET http://localhost:8080/test/review?textQuery=얼음나라화천 산천어축제
+
+## 리뷰 Biz
+### 리뷰 생성
+POST http://localhost:8080/reviews
+Content-Type: application/json
+
+{
+  "placeId": 2714406,
+  "contentTypeId": 32,
+  "title" : "신라스테이 서부산",
+  "areaCode": 1,
+  "rating": 3,
+  "content": "굿굿44",
+  "images": [
+    "http://tong.visitkorea.or.kr/cms/resource/01/3023101_image2_1.jpg",
+    "http://tong.visitkorea.or.kr/cms/resource/09/3023109_image2_1.jpg"
+  ],
+  "visitedAt": "2024-01-04"
+}
+
+### 리뷰 수정
+PATCH http://localhost:8080/reviews
+Content-Type: application/json
+
+
+{
+  "reviewId" : 1,
+  "rating" : 5,
+  "content" : "다시 생각해보니 별점 5점",
+  "images" : [
+    "http://tong.visitkorea.or.kr/cms/resource/01/3023101_image2_1.jpg",
+    "http://tong.visitkorea.or.kr/cms/resource/09/3023109_image2_1.jpg"
+  ],
+  "visitedAt": "2024-01-01"
+}
+
+### 리뷰 삭제
+DELETE http://localhost:8080/reviews/1
+
+### 상세 페이지 리뷰 조회 (리뷰 개수+ 별점 제외)
+GET http://localhost:8080/reviews?page=0&size=10
+Content-Type: application/json
+
+{
+  "placeId" : 2807380,
+  "placeTitle" : "감자밭",
+  "contentTypeId": 39
+}
+
+### 내가 쓴 리뷰 조회
+GET http://localhost:8080/reviews/my
+
+### 장소에 대한 리뷰 개수 및 별점 조회
+GET http://localhost:8080/reviews/rating
+Content-Type: application/json
+
+{
+  "placeId" : 2807380,
+  "placeTitle" : "감자밭",
+  "contentTypeId": 39
+}


### PR DESCRIPTION
## 변경사항


- 특정 장소의 Google 리뷰 조회 기능
- 특정 장소의 리뷰 총 개수, 별점 평점 조회 기능
- Google + 앱 자체 리뷰 통합 조회 기능
- 현재 버전은 Google API를 호출하지 않고 JSON파일에서 읽어오는 동작을 수행합니다.

### Issue Link - #35 

-----

## 체크리스트

리뷰 요청 전에 확인해야 할 사항들을 나열해주세요.

- [ ] 특정 장소에 대한 Google 리뷰와 자체 앱 리뷰가 함께 조회 가능한가요?
- [ ] 리뷰 조회, 리뷰 별점+총 개수 조회가 따로 동작하나요?
- [ ] 내가 쓴 리뷰 목록을 조회/수정/삭제 할 수 있나요?
- [ ] review HTTP 요청이 잘 동작하나요?

-----

## 참고

각 예시로 선정된 장소들의 `contentTypeId`, `placeTitle` ,`placeId` 은 아래와 같습니다.

12:관광지, 최남단체험감귤농장, 635928
14:문화시설, 호암미술관, 129765
15:축제공연행사, 태백산 눈축제, 406912
28:레포츠, 전주월드컵경기장, 131722
32:숙박, 신라스테이 서부산, 2714406
38:쇼핑, 더현대 서울, 2708109
39:음식점, 감자밭, 2807380 
