### PR TITLE
[Refactor] 투표 도메인 분리

### DIFF
--- a/app/src/main/java/fc/be/app/domain/space/entity/Space.java
+++ b/app/src/main/java/fc/be/app/domain/space/entity/Space.java
@@ -1,20 +1,18 @@
 package fc.be.app.domain.space.entity;
 
-import static fc.be.app.domain.space.exception.SpaceErrorCode.INVALID_START_DATE;
-
 import fc.be.app.domain.space.exception.SpaceException;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.time.LocalDate;
-import java.util.List;
+import fc.be.app.domain.vote.entity.Vote;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static fc.be.app.domain.space.exception.SpaceErrorCode.INVALID_START_DATE;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/app/src/main/java/fc/be/app/domain/vote/entity/Candidate.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/Candidate.java
@@ -1,12 +1,15 @@
-package fc.be.app.domain.space.entity;
+package fc.be.app.domain.vote.entity;
 
-import fc.be.app.domain.place.Place;
 import fc.be.app.domain.member.entity.Member;
+import fc.be.app.domain.place.Place;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
+
+import java.util.List;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -23,10 +26,10 @@ public class Candidate {
     @Comment("작성자(FK)")
     private Member member;
 
-    @ManyToOne
+    @OneToMany(mappedBy = "candidate")
     @JoinColumn(name = "voted_id")
     @Comment("후보에 투표한 회원 id(FK)")
-    private VotedMember votedMember;
+    private List<VotedMember> votedMember;
 
     @ManyToOne
     @JoinColumn(name = "place_id")
@@ -40,4 +43,28 @@ public class Candidate {
 
     @Comment("후보지에 대한 한줄평")
     private String tagline;
+
+    @Builder
+    private Candidate(Long id, Member member, List<VotedMember> votedMember, Place place, Vote vote, String tagline) {
+        this.id = id;
+        this.member = member;
+        this.votedMember = votedMember;
+        this.place = place;
+        this.vote = vote;
+        this.tagline = tagline;
+    }
+
+    public void vote(Vote vote, Member member) {
+        VotedMember voteMember = VotedMember.builder()
+                .vote(vote)
+                .candidate(this)
+                .member(member)
+                .build();
+
+        votedMember.add(voteMember);
+    }
+
+    void setVote(Vote vote) {
+        this.vote = vote;
+    }
 }

--- a/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
@@ -1,5 +1,7 @@
-package fc.be.app.domain.space.entity;
+package fc.be.app.domain.vote.entity;
 
+import fc.be.app.domain.member.entity.Member;
+import fc.be.app.domain.space.entity.Space;
 import fc.be.app.domain.space.vo.VoteStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -21,7 +23,7 @@ public class Vote {
     @Comment("투표 id")
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "space_id")
     @Comment("여행스페이스 식별자")
     private Space space;
@@ -33,7 +35,20 @@ public class Vote {
     @Comment("투표상태")
     private VoteStatus status;
 
+    @ManyToOne
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    @Comment("투표를 만든 사람")
+    private Member owner;
+
     @OneToMany(mappedBy = "vote")
     @Comment("후보지")
     private List<Candidate> candidates;
+
+    @OneToMany(mappedBy = "vote")
+    private List<VotedMember> votedMembers;
+
+    public void addCandidate(Candidate candidate) {
+        candidate.setVote(this);
+        this.candidates.add(candidate);
+    }
 }

--- a/app/src/main/java/fc/be/app/domain/vote/entity/VotedMember.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/VotedMember.java
@@ -1,8 +1,9 @@
-package fc.be.app.domain.space.entity;
+package fc.be.app.domain.vote.entity;
 
 import fc.be.app.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
@@ -26,4 +27,17 @@ public class VotedMember {
     @JoinColumn(name = "member_id")
     @Comment("투표한 멤버 id")
     private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "vote_id")
+    @Comment("투표 id")
+    private Vote vote;
+
+    @Builder
+    private VotedMember(Long id, Candidate candidate, Member member, Vote vote) {
+        this.id = id;
+        this.candidate = candidate;
+        this.member = member;
+        this.vote = vote;
+    }
 }


### PR DESCRIPTION
## motivation
- 투표는 스페이스와는 다른 도메인입니다. 도메인 라이프사이클도 다르며, 관심사 또한 분리가 될 수 있습니다. 이를 해결하기 위해서 vote 도메인을 따로 생성해 분리를 진행했습니다.

## modification
- `domain.space`에서 `domain.vote`으로 이동.

### Issue Link - #62 

-----

## 체크리스트
- [x] 의존성 분리의 이유가 명확한가요?
