### PR TITLE
Feature/#21 token authentication

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-ses:3.1.0'
 
+    // jwt
+    implementation 'com.auth0:java-jwt:4.4.0'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/app/src/main/java/fc/be/app/global/config/RedisConfig.java
+++ b/app/src/main/java/fc/be/app/global/config/RedisConfig.java
@@ -1,0 +1,30 @@
+package fc.be.app.global.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fc.be.app.global.config.security.model.token.RefreshToken;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisTemplate<String, RefreshToken> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, RefreshToken> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        Jackson2JsonRedisSerializer<RefreshToken> jsonSerializer = new Jackson2JsonRedisSerializer<>(objectMapper, RefreshToken.class);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(jsonSerializer);
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/app/src/main/java/fc/be/app/global/config/security/SecurityAppConfig.java
+++ b/app/src/main/java/fc/be/app/global/config/security/SecurityAppConfig.java
@@ -1,7 +1,10 @@
 package fc.be.app.global.config.security;
 
+import fc.be.app.global.config.security.filter.JwtAuthenticationFilter;
 import fc.be.app.global.config.security.properties.CorsProperties;
+import fc.be.app.global.config.security.properties.TokenProperties;
 import fc.be.app.global.config.security.provider.AuthenticationDetails;
+import fc.be.app.global.config.security.provider.JwtAuthenticationProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +25,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityAppConfig {
     private final CorsProperties corsProperties;
+    private final TokenProperties tokenProperties;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -31,6 +35,11 @@ public class SecurityAppConfig {
     @Bean
     public AuthenticationDetailsSource<HttpServletRequest, WebAuthenticationDetails> authenticationDetailsSource() {
         return context -> new AuthenticationDetails(context);
+    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtAuthenticationProvider provider) {
+        return new JwtAuthenticationFilter(provider, authenticationDetailsSource(), tokenProperties);
     }
 
     @Bean

--- a/app/src/main/java/fc/be/app/global/config/security/exception/InvalidJwtException.java
+++ b/app/src/main/java/fc/be/app/global/config/security/exception/InvalidJwtException.java
@@ -1,0 +1,14 @@
+package fc.be.app.global.config.security.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class InvalidJwtException extends AuthenticationException {
+
+    public InvalidJwtException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public InvalidJwtException(String msg) {
+        super(msg);
+    }
+}

--- a/app/src/main/java/fc/be/app/global/config/security/filter/JwtAuthenticationFilter.java
+++ b/app/src/main/java/fc/be/app/global/config/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,102 @@
+package fc.be.app.global.config.security.filter;
+
+import fc.be.app.global.config.security.model.token.JwtAuthenticationToken;
+import fc.be.app.global.config.security.model.token.TokenPair;
+import fc.be.app.global.config.security.properties.TokenProperties;
+import fc.be.app.global.config.security.provider.JwtAuthenticationProvider;
+import fc.be.app.global.util.CookieUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.authentication.AuthenticationDetailsSource;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder.getContextHolderStrategy();
+
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource;
+    private final TokenProperties tokenProperties;
+
+    public JwtAuthenticationFilter(JwtAuthenticationProvider jwtAuthenticationProvider, AuthenticationDetailsSource<HttpServletRequest, ?> authenticationDetailsSource, TokenProperties tokenProperties) {
+        this.jwtAuthenticationProvider = jwtAuthenticationProvider;
+        this.authenticationDetailsSource = authenticationDetailsSource;
+        this.tokenProperties = tokenProperties;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        if (this.securityContextHolderStrategy.getContext().getAuthentication() != null) {
+            this.logger.debug(LogMessage
+                    .of(() -> "SecurityContextHolder not populated with jwt token, as it already contained: '"
+                            + this.securityContextHolderStrategy.getContext().getAuthentication() + "'"));
+            chain.doFilter(request, response);
+            return;
+        }
+        Optional<Cookie> accessToken = CookieUtil.getCookie(request, tokenProperties.getAccessTokenName());
+        Optional<Cookie> refreshToken = CookieUtil.getCookie(request, tokenProperties.getRefreshTokenName());
+        if (accessToken.isPresent()) {
+            String accessTokenValue = accessToken.map(Cookie::getValue).orElse("");
+            String refreshTokenValue = refreshToken.map(Cookie::getValue).orElse("");
+            TokenPair tokenPair = new TokenPair(accessTokenValue, refreshTokenValue, false);
+            JwtAuthenticationToken jwtAuth = JwtAuthenticationToken.unauthenticated(null, tokenPair);
+            setDetails(request, jwtAuth);
+            // Attempt authentication via AuthenticationManager
+            try {
+                Authentication authResult = this.jwtAuthenticationProvider.authenticate(jwtAuth);
+                if (authResult == null) {
+                    // return immediately as subclass has indicated that it hasn't completed
+                    return;
+                }
+                SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
+                context.setAuthentication(authResult);
+                this.securityContextHolderStrategy.setContext(context);
+                onSuccessfulAuthentication(request, response, authResult);
+                this.logger.debug(
+                        LogMessage.of(() -> "SecurityContextHolder populated with jwt token: '"
+                                + this.securityContextHolderStrategy.getContext().getAuthentication()
+                                + "'"));
+            } catch (AuthenticationException ex) {
+                this.logger.debug(LogMessage
+                                .format(
+                                        "SecurityContextHolder not populated with jwt token, "
+                                                + "as AuthenticationManager rejected Authentication returned "
+                                                + "by JwtProvider: '%s'; "
+                                                + "invalidating jwt token", jwtAuth),
+                        ex);
+                onUnsuccessfulAuthentication(request, response, ex);
+            }
+        }
+        chain.doFilter(request, response);
+    }
+
+    protected void setDetails(HttpServletRequest request, JwtAuthenticationToken authRequest) {
+        authRequest.setDetails(this.authenticationDetailsSource.buildDetails(request));
+    }
+
+    protected void onSuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, Authentication authResult) {
+        if (authResult instanceof JwtAuthenticationToken jwtAuthToken && jwtAuthToken.getCredentials() != null) {
+            TokenPair newTokenPair = (TokenPair) jwtAuthToken.getCredentials();
+            if (newTokenPair.isRegenerated()) {
+                CookieUtil.addCookie(response, tokenProperties.getAccessTokenName(), newTokenPair.accessToken(), Integer.parseInt(tokenProperties.getAccessTokenCookieExpireTime()));
+            }
+        }
+    }
+
+    protected void onUnsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+
+    }
+}

--- a/app/src/main/java/fc/be/app/global/config/security/filter/JwtAuthenticationFilter.java
+++ b/app/src/main/java/fc/be/app/global/config/security/filter/JwtAuthenticationFilter.java
@@ -17,13 +17,11 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Optional;
 
-@Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private SecurityContextHolderStrategy securityContextHolderStrategy = SecurityContextHolder.getContextHolderStrategy();
 

--- a/app/src/main/java/fc/be/app/global/config/security/handler/LoginAuthenticationSuccessHandler.java
+++ b/app/src/main/java/fc/be/app/global/config/security/handler/LoginAuthenticationSuccessHandler.java
@@ -1,5 +1,6 @@
 package fc.be.app.global.config.security.handler;
 
+import com.auth0.jwt.exceptions.JWTCreationException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import fc.be.app.global.config.security.model.token.LoginAuthenticationToken;
 import fc.be.app.global.config.security.model.user.UserPrincipal;
@@ -14,6 +15,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -41,7 +43,12 @@ public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessH
         UserPrincipal principal = (UserPrincipal) loginAuthentication.getPrincipal();
 
         // response
-        String accessToken = jwtService.generateAccessToken(principal);
+        String accessToken;
+        try {
+            accessToken = jwtService.generateAccessToken(principal);
+        } catch (JWTCreationException ex) {
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex);
+        }
         CookieUtil.addCookie(response, tokenProperties.getAccessTokenName(), accessToken, Integer.parseInt(tokenProperties.getAccessTokenCookieExpireTime()));
 
         String refreshToken = refreshTokenService.refresh(accessToken, principal, (AuthenticationDetails) loginAuthentication.getDetails());

--- a/app/src/main/java/fc/be/app/global/config/security/handler/LoginAuthenticationSuccessHandler.java
+++ b/app/src/main/java/fc/be/app/global/config/security/handler/LoginAuthenticationSuccessHandler.java
@@ -1,7 +1,14 @@
 package fc.be.app.global.config.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fc.be.app.global.config.security.model.token.LoginAuthenticationToken;
+import fc.be.app.global.config.security.model.user.UserPrincipal;
+import fc.be.app.global.config.security.properties.TokenProperties;
+import fc.be.app.global.config.security.provider.AuthenticationDetails;
+import fc.be.app.global.config.security.service.RefreshTokenService;
 import fc.be.app.global.http.ApiResponse;
+import fc.be.app.global.util.CookieUtil;
+import fc.be.app.global.util.JwtService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -9,14 +16,37 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Component
 public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private final JwtService jwtService;
+    private final RefreshTokenService refreshTokenService;
+    private final TokenProperties tokenProperties;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public LoginAuthenticationSuccessHandler(JwtService jwtService, RefreshTokenService refreshTokenService, TokenProperties tokenProperties) {
+        this.jwtService = jwtService;
+        this.refreshTokenService = refreshTokenService;
+        this.tokenProperties = tokenProperties;
+    }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        LoginAuthenticationToken loginAuthentication = (LoginAuthenticationToken) authentication;
+
+        // get userPrincipal
+        UserPrincipal principal = (UserPrincipal) loginAuthentication.getPrincipal();
+
+        // response
+        String accessToken = jwtService.generateAccessToken(principal);
+        CookieUtil.addCookie(response, tokenProperties.getAccessTokenName(), accessToken, Integer.parseInt(tokenProperties.getAccessTokenCookieExpireTime()));
+
+        String refreshToken = refreshTokenService.refresh(accessToken, principal, (AuthenticationDetails) loginAuthentication.getDetails());
+        CookieUtil.addCookie(response, tokenProperties.getRefreshTokenName(), refreshToken, Integer.parseInt(tokenProperties.getRefreshTokenCookieExpireTime()));
+
         response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/app/src/main/java/fc/be/app/global/config/security/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/app/src/main/java/fc/be/app/global/config/security/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,22 +1,80 @@
 package fc.be.app.global.config.security.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import fc.be.app.domain.member.service.MemberQuery;
+import fc.be.app.domain.member.vo.AuthProvider;
+import fc.be.app.global.config.security.converter.Converter;
+import fc.be.app.global.config.security.converter.ProviderUserConvertRequest;
+import fc.be.app.global.config.security.model.user.ProviderUser;
+import fc.be.app.global.config.security.model.user.UserPrincipal;
+import fc.be.app.global.config.security.properties.TokenProperties;
+import fc.be.app.global.config.security.provider.AuthenticationDetails;
+import fc.be.app.global.config.security.service.RefreshTokenService;
 import fc.be.app.global.http.ApiResponse;
+import fc.be.app.global.util.CookieUtil;
+import fc.be.app.global.util.JwtService;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Component
 public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+    private final Converter<ProviderUserConvertRequest, ProviderUser> converter;
+    private final MemberQuery memberQuery;
+    private final JwtService jwtService;
+    private final ClientRegistrationRepository clientRegistrationRepository;
+    private final RefreshTokenService refreshTokenService;
+    private final TokenProperties tokenProperties;
     private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public OAuth2AuthenticationSuccessHandler(MemberQuery memberQuery, Converter<ProviderUserConvertRequest, ProviderUser> converter, JwtService jwtService, ClientRegistrationRepository clientRegistrationRepository, RefreshTokenService refreshTokenService, TokenProperties tokenProperties) {
+        this.memberQuery = memberQuery;
+        this.converter = converter;
+        this.jwtService = jwtService;
+        this.clientRegistrationRepository = clientRegistrationRepository;
+        this.refreshTokenService = refreshTokenService;
+        this.tokenProperties = tokenProperties;
+    }
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        OAuth2AuthenticationToken oauth2Authentication = (OAuth2AuthenticationToken) authentication;
+        // get clientRegistration
+        String authorizedClientRegistrationId = oauth2Authentication.getAuthorizedClientRegistrationId();
+        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(authorizedClientRegistrationId);
+
+        // get principal
+        OAuth2User principal = oauth2Authentication.getPrincipal();
+        ProviderUserConvertRequest convertRequest = new ProviderUserConvertRequest(clientRegistration, principal);
+        ProviderUser providerUser = converter.convert(convertRequest);
+        String email = providerUser.getEmail();
+        AuthProvider authProvider = AuthProvider.of(authorizedClientRegistrationId);
+
+        // get member
+        MemberQuery.ProviderMemberRequest providerMemberRequest = new MemberQuery.ProviderMemberRequest(authProvider, email);
+        MemberQuery.MemberResponse memberResponse = memberQuery.find(providerMemberRequest).orElseThrow();
+
+        // convert to userPrincipal
+        UserPrincipal userPrincipal = new UserPrincipal(memberResponse.id(), memberResponse.email(), memberResponse.provider());
+
+        // response
+        String accessToken = jwtService.generateAccessToken(userPrincipal);
+        CookieUtil.addCookie(response, tokenProperties.getAccessTokenName(), accessToken, Integer.parseInt(tokenProperties.getAccessTokenExpireTime()));
+
+        String refreshToken = refreshTokenService.refresh(accessToken, userPrincipal, (AuthenticationDetails) oauth2Authentication.getDetails());
+        CookieUtil.addCookie(response, tokenProperties.getRefreshTokenName(), refreshToken, Integer.parseInt(tokenProperties.getRefreshTokenCookieExpireTime()));
+
         response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");

--- a/app/src/main/java/fc/be/app/global/config/security/model/token/JwtAuthenticationToken.java
+++ b/app/src/main/java/fc/be/app/global/config/security/model/token/JwtAuthenticationToken.java
@@ -1,0 +1,53 @@
+package fc.be.app.global.config.security.model.token;
+
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+    private final Object principal;
+    private final TokenPair tokenPair;
+
+    public JwtAuthenticationToken(Object principal, TokenPair tokenPair) {
+        super(null);
+        this.principal = principal;
+        this.tokenPair = tokenPair;
+        setAuthenticated(false);
+    }
+
+    public JwtAuthenticationToken(Object principal, TokenPair tokenPair, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.tokenPair = tokenPair;
+        super.setAuthenticated(true); // must use super, as we override
+    }
+
+    public static JwtAuthenticationToken unauthenticated(Object principal, TokenPair tokenPair) {
+        return new JwtAuthenticationToken(principal, tokenPair);
+    }
+
+    public static JwtAuthenticationToken authenticated(Object principal, TokenPair tokenPair, Collection<? extends GrantedAuthority> authorities) {
+        return new JwtAuthenticationToken(principal, tokenPair, authorities);
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return this.principal;
+    }
+
+    @Override
+    public Object getCredentials() {
+        return this.tokenPair;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        super.setAuthenticated(false);
+    }
+
+    @Override
+    public void eraseCredentials() {
+        super.eraseCredentials();
+    }
+}

--- a/app/src/main/java/fc/be/app/global/config/security/model/token/RefreshToken.java
+++ b/app/src/main/java/fc/be/app/global/config/security/model/token/RefreshToken.java
@@ -1,40 +1,20 @@
 package fc.be.app.global.config.security.model.token;
 
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.Objects;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
 public class RefreshToken implements Serializable {
-    private static final long serialVersionUID = 1L;
-
     private String accessToken;
     private Long userId;
     private String clientIp;
     private String userAgent;
     private String value;
-
-    public RefreshToken(String accessToken, Long userId, String clientIp, String userAgent, String value) {
-        this.accessToken = accessToken;
-        this.userId = userId;
-        this.clientIp = clientIp;
-        this.userAgent = userAgent;
-        this.value = value;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        RefreshToken that = (RefreshToken) o;
-        return Objects.equals(accessToken, that.accessToken) && Objects.equals(userId, that.userId) && Objects.equals(clientIp, that.clientIp) && Objects.equals(userAgent, that.userAgent) && Objects.equals(value, that.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(accessToken, userId, clientIp, userAgent, value);
-    }
 }

--- a/app/src/main/java/fc/be/app/global/config/security/model/token/RefreshToken.java
+++ b/app/src/main/java/fc/be/app/global/config/security/model/token/RefreshToken.java
@@ -1,0 +1,40 @@
+package fc.be.app.global.config.security.model.token;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor
+public class RefreshToken implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String accessToken;
+    private Long userId;
+    private String clientIp;
+    private String userAgent;
+    private String value;
+
+    public RefreshToken(String accessToken, Long userId, String clientIp, String userAgent, String value) {
+        this.accessToken = accessToken;
+        this.userId = userId;
+        this.clientIp = clientIp;
+        this.userAgent = userAgent;
+        this.value = value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RefreshToken that = (RefreshToken) o;
+        return Objects.equals(accessToken, that.accessToken) && Objects.equals(userId, that.userId) && Objects.equals(clientIp, that.clientIp) && Objects.equals(userAgent, that.userAgent) && Objects.equals(value, that.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(accessToken, userId, clientIp, userAgent, value);
+    }
+}

--- a/app/src/main/java/fc/be/app/global/config/security/model/token/TokenPair.java
+++ b/app/src/main/java/fc/be/app/global/config/security/model/token/TokenPair.java
@@ -1,0 +1,8 @@
+package fc.be.app.global.config.security.model.token;
+
+public record TokenPair(
+        String accessToken,
+        String refreshToken,
+        boolean isRegenerated
+) {
+}

--- a/app/src/main/java/fc/be/app/global/config/security/properties/TokenProperties.java
+++ b/app/src/main/java/fc/be/app/global/config/security/properties/TokenProperties.java
@@ -1,0 +1,23 @@
+package fc.be.app.global.config.security.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties("jwt")
+@Getter
+@Setter
+public class TokenProperties {
+    private String secretKey;
+    private String accessTokenName;
+    private String refreshTokenName;
+    private String accessTokenExpireTime;
+    private String accessTokenCookieExpireTime;
+    private String refreshTokenExpireTime;
+    private String refreshTokenCookieExpireTime;
+    private String issuer;
+    private String accessTokenAuthenticationProperty;
+    private String accessTokenAuthoritiesProperty;
+}

--- a/app/src/main/java/fc/be/app/global/config/security/provider/JwtAuthenticationProvider.java
+++ b/app/src/main/java/fc/be/app/global/config/security/provider/JwtAuthenticationProvider.java
@@ -1,6 +1,7 @@
 package fc.be.app.global.config.security.provider;
 
 import com.auth0.jwt.JWT;
+import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import com.auth0.jwt.interfaces.DecodedJWT;
@@ -12,6 +13,7 @@ import fc.be.app.global.config.security.properties.TokenProperties;
 import fc.be.app.global.config.security.service.RefreshTokenService;
 import fc.be.app.global.util.JwtService;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -61,6 +63,8 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
             }
         } catch (JWTVerificationException ex) {
             throw new InvalidJwtException(ex.getMessage(), ex);
+        } catch (JWTCreationException ex) {
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex);
         }
         return authResult;
     }

--- a/app/src/main/java/fc/be/app/global/config/security/provider/JwtAuthenticationProvider.java
+++ b/app/src/main/java/fc/be/app/global/config/security/provider/JwtAuthenticationProvider.java
@@ -1,0 +1,72 @@
+package fc.be.app.global.config.security.provider;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import fc.be.app.global.config.security.exception.InvalidJwtException;
+import fc.be.app.global.config.security.model.token.JwtAuthenticationToken;
+import fc.be.app.global.config.security.model.token.TokenPair;
+import fc.be.app.global.config.security.model.user.UserPrincipal;
+import fc.be.app.global.config.security.properties.TokenProperties;
+import fc.be.app.global.config.security.service.RefreshTokenService;
+import fc.be.app.global.util.JwtService;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+    private final RefreshTokenService refreshTokenService;
+    private final JwtService jwtService;
+    private final TokenProperties tokenProperties;
+
+    public JwtAuthenticationProvider(RefreshTokenService refreshTokenService, JwtService jwtService, TokenProperties tokenProperties) {
+        this.refreshTokenService = refreshTokenService;
+        this.jwtService = jwtService;
+        this.tokenProperties = tokenProperties;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
+        TokenPair tokenPair = (TokenPair) jwtAuthentication.getCredentials();
+        AuthenticationDetails details = (AuthenticationDetails) authentication.getDetails();
+        JwtAuthenticationToken authResult = null;
+        try {
+            DecodedJWT decodedJwt = jwtService.verify(tokenPair.accessToken());
+            UserPrincipal userPrincipal =
+                    decodedJwt.getClaim(tokenProperties.getAccessTokenAuthenticationProperty()).as(UserPrincipal.class);
+            List<SimpleGrantedAuthority> authorities =
+                    decodedJwt.getClaim(tokenProperties.getAccessTokenAuthoritiesProperty()).asList(SimpleGrantedAuthority.class);
+            authResult = JwtAuthenticationToken.authenticated(userPrincipal, null, authorities);
+        } catch (TokenExpiredException ex) {
+            DecodedJWT decodedJwt = JWT.decode(tokenPair.accessToken());
+            UserPrincipal userPrincipal =
+                    decodedJwt.getClaim(tokenProperties.getAccessTokenAuthenticationProperty()).as(UserPrincipal.class);
+            List<SimpleGrantedAuthority> authorities =
+                    decodedJwt.getClaim(tokenProperties.getAccessTokenAuthoritiesProperty()).asList(SimpleGrantedAuthority.class);
+            boolean isValidRefreshToken = refreshTokenService.isValid(tokenPair, userPrincipal, details);
+            if (isValidRefreshToken) {
+                String newAccessToken = jwtService.generateAccessToken(userPrincipal, authorities);
+                TokenPair newTokenPair = new TokenPair(newAccessToken, tokenPair.refreshToken(), true);
+                authResult = JwtAuthenticationToken.authenticated(userPrincipal, newTokenPair, authorities);
+                authResult.setDetails(authentication.getDetails());
+            } else {
+                authResult = null;
+            }
+        } catch (JWTVerificationException ex) {
+            throw new InvalidJwtException(ex.getMessage(), ex);
+        }
+        return authResult;
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+}

--- a/app/src/main/java/fc/be/app/global/config/security/provider/JwtAuthenticationProvider.java
+++ b/app/src/main/java/fc/be/app/global/config/security/provider/JwtAuthenticationProvider.java
@@ -36,7 +36,7 @@ public class JwtAuthenticationProvider implements AuthenticationProvider {
         JwtAuthenticationToken jwtAuthentication = (JwtAuthenticationToken) authentication;
         TokenPair tokenPair = (TokenPair) jwtAuthentication.getCredentials();
         AuthenticationDetails details = (AuthenticationDetails) authentication.getDetails();
-        JwtAuthenticationToken authResult = null;
+        JwtAuthenticationToken authResult;
         try {
             DecodedJWT decodedJwt = jwtService.verify(tokenPair.accessToken());
             UserPrincipal userPrincipal =

--- a/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
+++ b/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
@@ -47,11 +47,7 @@ public class RefreshTokenService {
             // expired
             return false;
         }
-        if (!storedRefreshToken.equals(requestedRefreshToken)) {
-            // invalid
-            return false;
-        }
-        return true;
+        return storedRefreshToken.equals(requestedRefreshToken);
     }
 
     /**

--- a/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
+++ b/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
@@ -1,0 +1,87 @@
+package fc.be.app.global.config.security.service;
+
+import fc.be.app.global.config.security.model.token.RefreshToken;
+import fc.be.app.global.config.security.model.token.TokenPair;
+import fc.be.app.global.config.security.model.user.UserPrincipal;
+import fc.be.app.global.config.security.properties.TokenProperties;
+import fc.be.app.global.config.security.provider.AuthenticationDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+    private final RedisTemplate<String, RefreshToken> redisTemplate;
+    private final TokenProperties tokenProperties;
+
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "refresh_token_";
+    private static final Duration REFRESH_TOKEN_DURATION = Duration.ofHours(2);
+
+    /**
+     * check validation of access-token
+     *
+     * @param tokenPair     access token과 refresh token
+     * @param userPrincipal login 당시의 user 정보 (현재 유저 X)
+     * @param details       현재 접속한 client-ip와 user-agent
+     * @return
+     */
+    public boolean isValid(TokenPair tokenPair, UserPrincipal userPrincipal, AuthenticationDetails details) {
+        String accessToken = tokenPair.accessToken();
+        String refreshToken = tokenPair.refreshToken();
+        if (!StringUtils.hasText(accessToken) || !StringUtils.hasText(refreshToken)) {
+            // no value
+            return false;
+        }
+        Long id = userPrincipal.id(); // TODO: access-token이 같으면 user-id도 당연히 같다고 보아야 하지 않을까?
+        String clientIp = details.getClientIp();
+        String userAgent = details.getUserAgent();
+
+        RefreshToken requestedRefreshToken = new RefreshToken(accessToken, id, clientIp, userAgent, refreshToken);
+        RefreshToken storedRefreshToken = getRefreshToken(accessToken);
+        if (storedRefreshToken == null) {
+            // expired
+            return false;
+        }
+        if (!storedRefreshToken.equals(requestedRefreshToken)) {
+            // invalid
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * generate refresh-token for requested access token
+     *
+     * @param accessToken
+     * @param userPrincipal
+     * @param details
+     * @return generated refresh token value for the requested access token
+     */
+    public String refresh(String accessToken, UserPrincipal userPrincipal, AuthenticationDetails details) {
+        String newRefreshTokenValue = UUID.randomUUID().toString();
+        RefreshToken newRefreshToken =
+                new RefreshToken(accessToken, userPrincipal.id(), details.getClientIp(), details.getUserAgent(), newRefreshTokenValue);
+        saveRefreshToken(newRefreshToken);
+        return newRefreshTokenValue;
+    }
+
+    private void saveRefreshToken(RefreshToken refreshToken) {
+        String key = REFRESH_TOKEN_KEY_PREFIX + refreshToken.getAccessToken();
+        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_DURATION);
+    }
+
+    private RefreshToken getRefreshToken(String accessToken) {
+        String key = REFRESH_TOKEN_KEY_PREFIX + accessToken;
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    private void deleteRefreshToken(String accessToken) {
+        String key = REFRESH_TOKEN_KEY_PREFIX + accessToken;
+        redisTemplate.delete(key);
+    }
+}

--- a/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
+++ b/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
@@ -53,9 +53,9 @@ public class RefreshTokenService {
     /**
      * generate refresh-token for requested access token
      *
-     * @param accessToken
-     * @param userPrincipal
-     * @param details
+     * @param accessToken   refresh token을 발급받고자 하는 대상 access token
+     * @param userPrincipal refresh token을 발급받고자 하는 유저
+     * @param details       refresh token을 발급받고자 하는 유저의 클라이언트 정보(ip, user-agent)
      * @return generated refresh token value for the requested access token
      */
     public String refresh(String accessToken, UserPrincipal userPrincipal, AuthenticationDetails details) {

--- a/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
+++ b/app/src/main/java/fc/be/app/global/config/security/service/RefreshTokenService.java
@@ -37,7 +37,7 @@ public class RefreshTokenService {
             // no value
             return false;
         }
-        Long id = userPrincipal.id(); // TODO: access-token이 같으면 user-id도 당연히 같다고 보아야 하지 않을까?
+        Long id = userPrincipal.id();
         String clientIp = details.getClientIp();
         String userAgent = details.getUserAgent();
 

--- a/app/src/main/java/fc/be/app/global/util/CookieUtil.java
+++ b/app/src/main/java/fc/be/app/global/util/CookieUtil.java
@@ -1,0 +1,48 @@
+package fc.be.app.global.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.util.Optional;
+
+public class CookieUtil {
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+        for (Cookie cookie : cookies) {
+            if (cookie.getName().equals(name)) {
+                return Optional.of(cookie);
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        //cookie.setDomain(HOST);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "Lax");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return;
+        }
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                cookie.setValue("");
+                cookie.setPath("/");
+                cookie.setMaxAge(0);
+                response.addCookie(cookie);
+            }
+        }
+    }
+}

--- a/app/src/main/java/fc/be/app/global/util/JwtService.java
+++ b/app/src/main/java/fc/be/app/global/util/JwtService.java
@@ -1,0 +1,87 @@
+package fc.be.app.global.util;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTCreator;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fc.be.app.global.config.security.model.user.UserPrincipal;
+import fc.be.app.global.config.security.properties.TokenProperties;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class JwtService {
+    private final Algorithm algorithm;
+    private final String issuer;
+    private final JWTVerifier verifier;
+    private final TokenProperties tokenProperties;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public JwtService(TokenProperties tokenProperties) {
+        this.algorithm = Algorithm.HMAC256(tokenProperties.getSecretKey());
+        this.issuer = tokenProperties.getIssuer();
+        this.verifier = JWT.require(algorithm).withIssuer(issuer).build();
+        this.tokenProperties = tokenProperties;
+    }
+
+    public String generateAccessToken(UserPrincipal userPrincipal) {
+        String subject = userPrincipal.email();
+        Map<String, Map<String, ?>> claim = new HashMap<>();
+        Map<String, Object> authenticationMap = objectMapper.convertValue(userPrincipal,
+                new TypeReference<Map<String, Object>>() {
+                });
+        claim.put(tokenProperties.getAccessTokenAuthenticationProperty(), authenticationMap);
+        Map<String, String[]> arrayClaim = new HashMap<>();
+        SimpleGrantedAuthority userAuthority = new SimpleGrantedAuthority("USER");
+        String[] _authorities = new String[]{userAuthority.getAuthority()};
+        arrayClaim.put(tokenProperties.getAccessTokenAuthoritiesProperty(), _authorities);
+        return generateToken(subject, claim, arrayClaim, Long.parseLong(tokenProperties.getAccessTokenExpireTime()));
+    }
+
+    public String generateAccessToken(UserPrincipal userPrincipal, Collection<? extends GrantedAuthority> authorities) {
+        String subject = userPrincipal.email();
+        Map<String, Map<String, ?>> claim = new HashMap<>();
+        Map<String, Object> authenticationMap = objectMapper.convertValue(userPrincipal,
+                new TypeReference<Map<String, Object>>() {
+                });
+        claim.put(tokenProperties.getAccessTokenAuthenticationProperty(), authenticationMap);
+        Map<String, String[]> arrayClaim = new HashMap<>();
+        String[] _authorities = authorities.stream().map(GrantedAuthority::getAuthority).toArray(String[]::new);
+        arrayClaim.put(tokenProperties.getAccessTokenAuthoritiesProperty(), _authorities);
+        return generateToken(subject, claim, arrayClaim, Long.parseLong(tokenProperties.getAccessTokenExpireTime()));
+    }
+
+    private String generateToken(String subject, Map<String, Map<String, ?>> claim, Map<String, String[]> arrayClaim, long expireSecond) {
+        LocalDateTime now = LocalDateTime.now();
+        JWTCreator.Builder builder = JWT.create();
+        builder.withSubject(subject);
+        for (Map.Entry<String, Map<String, ?>> claimEntry : claim.entrySet()) {
+            builder.withClaim(claimEntry.getKey(), claimEntry.getValue());
+        }
+        for (Map.Entry<String, String[]> arrayClaimEntry : arrayClaim.entrySet()) {
+            builder.withArrayClaim(arrayClaimEntry.getKey(), arrayClaimEntry.getValue());
+        }
+        builder
+                .withIssuer(issuer)
+                .withIssuedAt(now.atZone(ZoneId.systemDefault()).toInstant())
+                .withExpiresAt(now.atZone(ZoneId.systemDefault()).plus(expireSecond, ChronoUnit.SECONDS).toInstant());
+        return builder.sign(algorithm);
+    }
+
+    public DecodedJWT verify(String token) throws JWTVerificationException {
+        return verifier.verify(token);
+    }
+}

--- a/app/src/main/java/fc/be/app/global/util/JwtService.java
+++ b/app/src/main/java/fc/be/app/global/util/JwtService.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;

--- a/app/src/main/java/fc/be/app/global/util/JwtService.java
+++ b/app/src/main/java/fc/be/app/global/util/JwtService.java
@@ -4,6 +4,7 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTCreator;
 import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTCreationException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -36,7 +37,7 @@ public class JwtService {
         this.tokenProperties = tokenProperties;
     }
 
-    public String generateAccessToken(UserPrincipal userPrincipal) {
+    public String generateAccessToken(UserPrincipal userPrincipal) throws JWTCreationException {
         String subject = userPrincipal.email();
         Map<String, Map<String, ?>> claim = new HashMap<>();
         Map<String, Object> authenticationMap = objectMapper.convertValue(userPrincipal,
@@ -50,7 +51,7 @@ public class JwtService {
         return generateToken(subject, claim, arrayClaim, Long.parseLong(tokenProperties.getAccessTokenExpireTime()));
     }
 
-    public String generateAccessToken(UserPrincipal userPrincipal, Collection<? extends GrantedAuthority> authorities) {
+    public String generateAccessToken(UserPrincipal userPrincipal, Collection<? extends GrantedAuthority> authorities) throws JWTCreationException {
         String subject = userPrincipal.email();
         Map<String, Map<String, ?>> claim = new HashMap<>();
         Map<String, Object> authenticationMap = objectMapper.convertValue(userPrincipal,
@@ -63,7 +64,7 @@ public class JwtService {
         return generateToken(subject, claim, arrayClaim, Long.parseLong(tokenProperties.getAccessTokenExpireTime()));
     }
 
-    private String generateToken(String subject, Map<String, Map<String, ?>> claim, Map<String, String[]> arrayClaim, long expireSecond) {
+    private String generateToken(String subject, Map<String, Map<String, ?>> claim, Map<String, String[]> arrayClaim, long expireSecond) throws JWTCreationException {
         LocalDateTime now = LocalDateTime.now();
         JWTCreator.Builder builder = JWT.create();
         builder.withSubject(subject);

--- a/app/src/main/java/fc/be/app/global/util/JwtService.java
+++ b/app/src/main/java/fc/be/app/global/util/JwtService.java
@@ -77,7 +77,7 @@ public class JwtService {
         builder
                 .withIssuer(issuer)
                 .withIssuedAt(now.atZone(ZoneId.systemDefault()).toInstant())
-                .withExpiresAt(now.atZone(ZoneId.systemDefault()).plus(expireSecond, ChronoUnit.SECONDS).toInstant());
+                .withExpiresAt(now.atZone(ZoneId.systemDefault()).plusSeconds(expireSecond).toInstant());
         return builder.sign(algorithm);
     }
 

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:4406/tripvote?characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:3306/tripvote?characterEncoding=UTF-8
     username: root
     password: root
 

--- a/app/src/main/resources/application-dev.yml
+++ b/app/src/main/resources/application-dev.yml
@@ -9,7 +9,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/tripvote?characterEncoding=UTF-8
+    url: jdbc:mysql://localhost:4406/tripvote?characterEncoding=UTF-8
     username: root
     password: root
 
@@ -32,3 +32,17 @@ spring:
 
 cors:
   allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:5174
+
+jwt:
+  secret-key: d9xfFo5p73CTZ346fGq3quGiHpUyCi/0rA0ti7bwHAP7da9oTa3eXCpSxrZBDF+s
+  access-token-name: access-token
+  access-token-authentication-property: authentication
+  access-token-authorities-property: authorities
+  access-token-expire-time: 1000000
+  access-token-cookie-expire-time: 1000000
+  refresh-token-name: refresh-token
+  refresh-token-expire-time: 1000000
+  refresh-token-cookie-expire-time: 1000000
+  issuer: tripvote-1
+
+domain: localhost:8080

--- a/app/src/main/resources/application-prod.yml
+++ b/app/src/main/resources/application-prod.yml
@@ -20,3 +20,17 @@ spring:
 
 cors:
   allowed-origins: https://tripvote.site
+
+jwt:
+  secret-key: ${JWTSECRETKEY}
+  access-token-name: ${ACCESSTOKENNAME}
+  access-token-authentication-property: ${ACCESSTOKENAUTHPROPERTY}
+  access-token-authorities-property: ${ACCESSTOKENAUTHGRPROPERTY}
+  access-token-expire-time: ${ACCESSTOKENVALIDSECOND}
+  access-token-cookie-expire-time: ${ACCESSTOKENCOOKIEEXPIRETIME}
+  refresh-token-name: ${REFRESHTOKENNAME}
+  refresh-token-expire-time: ${REFRESHTOKENVALIDSECOND}
+  refresh-token-cookie-expire-time: ${REFRESHTOKENCOOKIEEXPIRETIME}
+  issuer: ${JWTISSUER}
+
+domain: ${DOMAIN}

--- a/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
+++ b/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
@@ -7,7 +7,6 @@ import fc.be.app.domain.space.dto.response.SpaceResponse;
 import fc.be.app.domain.space.service.SpaceService;
 import fc.be.app.global.config.security.SecurityAppConfig;
 import fc.be.app.global.config.security.SecurityConfig;
-import fc.be.app.global.config.security.filter.JwtAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
+++ b/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = SpaceController.class,
         excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, SecurityAppConfig.class, JwtAuthenticationFilter.class})
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, SecurityAppConfig.class})
         },
         excludeAutoConfiguration = {
                 SecurityAutoConfiguration.class,

--- a/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
+++ b/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
@@ -7,6 +7,7 @@ import fc.be.app.domain.space.dto.response.SpaceResponse;
 import fc.be.app.domain.space.service.SpaceService;
 import fc.be.app.global.config.security.SecurityAppConfig;
 import fc.be.app.global.config.security.SecurityConfig;
+import fc.be.app.global.config.security.filter.JwtAuthenticationFilter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WebMvcTest(controllers = SpaceController.class,
         excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, SecurityAppConfig.class})
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = {SecurityConfig.class, SecurityAppConfig.class, JwtAuthenticationFilter.class})
         },
         excludeAutoConfiguration = {
                 SecurityAutoConfiguration.class,

--- a/app/src/test/resources/application-test.yml
+++ b/app/src/test/resources/application-test.yml
@@ -21,3 +21,20 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.H2Dialect
+
+cors:
+  allowed-origins: http://localhost:3000,http://localhost:5173,http://localhost:5174
+
+jwt:
+  secret-key: d9xfFo5p73CTZ346fGq3quGiHpUyCi/0rA0ti7bwHAP7da9oTa3eXCpSxrZBDF+s
+  access-token-name: access-token
+  access-token-authentication-property: authentication
+  access-token-authorities-property: authorities
+  access-token-expire-time: 1000000
+  access-token-cookie-expire-time: 1000000
+  refresh-token-name: refresh-token
+  refresh-token-expire-time: 1000000
+  refresh-token-cookie-expire-time: 1000000
+  issuer: tripvote-1
+
+domain: localhost:8080


### PR DESCRIPTION
## 변경사항

### token을 이용한 세션 유지 필터 구현
OAuth2로그인 또는 Login이 성공했을 때 SuccessHandler에서 access-token 및 refresh-token을 발급받아 cookie에 넣어줍니다.
이후의 요청은 cookie에 있는 access-token과 refresh-token을 `JwtService`에서 파싱해서 `UserPrincipal`을 만들어 `SecurityContextHolder`에 넣어줍니다. 


### Issue Link - #21 


## 체크리스트

리뷰 요청 전에 확인해야 할 사항들을 나열해주세요.

- [ ] 내 코드를 스스로 검토했나요?
- [ ] 핵심 기능에 대해 충분한 테스트를 수행했나요?
- [ ] 분석이 필요한가요?
