### PR TITLE
[Feat/Fix] #86 여행스페이스 조회 시 초대멤버 정보 함께 조회

### DIFF
--- a/app/src/main/java/fc/be/app/domain/space/controller/SpaceController.java
+++ b/app/src/main/java/fc/be/app/domain/space/controller/SpaceController.java
@@ -8,10 +8,12 @@ import fc.be.app.domain.space.dto.response.JourneyResponse;
 import fc.be.app.domain.space.dto.response.JourneysResponse;
 import fc.be.app.domain.space.dto.response.SpaceResponse;
 import fc.be.app.domain.space.service.SpaceService;
+import fc.be.app.global.config.security.model.user.UserPrincipal;
 import fc.be.app.global.http.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -23,10 +25,8 @@ public class SpaceController {
     private final SpaceService spaceService;
 
     @PostMapping
-    public ApiResponse<SpaceResponse> createSpace() {
-        // todo 로그인 구현 시 @AuthenticationPrincipal 어노테이션 등으로 변경할 예정
-        Long memberId = 1L;
-        return ApiResponse.created(spaceService.createSpace(memberId));
+    public ApiResponse<SpaceResponse> createSpace(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponse.created(spaceService.createSpace(userPrincipal.id()));
     }
 
     @GetMapping("/{spaceId}")
@@ -53,10 +53,11 @@ public class SpaceController {
     }
 
     @PutMapping("/{spaceId}/exit")
-    public ApiResponse<Void> exitSpace(@PathVariable Long spaceId) {
-        // todo 로그인 구현 시 @AuthenticationPrincipal 어노테이션 등으로 변경할 예정
-        Long memberId = 1L;
-        spaceService.exitSpace(spaceId, memberId);
+    public ApiResponse<Void> exitSpace(
+            @PathVariable Long spaceId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        spaceService.exitSpace(spaceId, userPrincipal.id());
         return ApiResponse.ok();
     }
 
@@ -65,14 +66,25 @@ public class SpaceController {
         return ApiResponse.ok(spaceService.getJourneyForSpace(spaceId));
     }
 
-    @PostMapping("/select-places")
-    public ApiResponse<JourneyResponse> selectedPlacesForSpace(@Valid @RequestBody SelectedPlaceRequest request) {
+    @PostMapping("/{spaceId}/places")
+    public ApiResponse<JourneyResponse> selectedPlacesForSpace(
+            @PathVariable Long spaceId,
+            @Valid @RequestBody SelectedPlaceRequest request
+    ) {
         return ApiResponse.ok(spaceService.selectedPlacesForSpace(request));
     }
 
-    @PutMapping("/select-places")
-    public ApiResponse<JourneysResponse> updatePlacesForSpace(@Valid @RequestBody SelectedPlacesRequest request) {
+    @PutMapping("/{spaceId}/places")
+    public ApiResponse<JourneysResponse> updatePlacesForSpace(
+            @PathVariable Long spaceId,
+            @Valid @RequestBody SelectedPlacesRequest request
+    ) {
         return ApiResponse.ok(spaceService.updatePlacesForSpace(request));
     }
 
+    @GetMapping
+    public ApiResponse<SpaceResponse> getLatestSpace() {
+        // todo API 명세를 위한 껍데기이며 최근 작업한 여행스페이스 검색로직 추가 예정
+        return ApiResponse.ok(SpaceResponse.builder().build());
+    }
 }

--- a/app/src/main/java/fc/be/app/domain/space/dto/response/SpaceResponse.java
+++ b/app/src/main/java/fc/be/app/domain/space/dto/response/SpaceResponse.java
@@ -1,25 +1,49 @@
 package fc.be.app.domain.space.dto.response;
 
+import fc.be.app.domain.space.entity.JoinedMember;
 import fc.be.app.domain.space.entity.Space;
+import lombok.Builder;
 
 import java.time.LocalDate;
-
-import lombok.Builder;
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 public record SpaceResponse(
         Long id,
         String title,
         LocalDate startDate,
-        LocalDate endDate
+        LocalDate endDate,
+        List<MemberInfo> members
 ) {
     public static SpaceResponse of(Space space) {
+
+        List<MemberInfo> memberInfos = new ArrayList<>();
+
+        for (JoinedMember joinedMember : space.getJoinedMembers()) {
+            memberInfos.add(MemberInfo.builder()
+                    .id(joinedMember.getId())
+                    .nickname(joinedMember.getMember().getNickname())
+                    .profile(joinedMember.getMember().getProfile())
+                    .build());
+        }
+
         return
                 SpaceResponse.builder()
                         .id(space.getId())
                         .title(space.getTitle())
                         .startDate(space.getStartDate())
                         .endDate(space.getEndDate())
+                        .members(memberInfos)
                         .build();
+    }
+
+    @Builder
+    private record MemberInfo(
+            Long id,
+            String nickname,
+            String profile
+    ) {
+
     }
 }

--- a/app/src/main/java/fc/be/app/domain/space/entity/Space.java
+++ b/app/src/main/java/fc/be/app/domain/space/entity/Space.java
@@ -1,5 +1,6 @@
 package fc.be.app.domain.space.entity;
 
+import fc.be.app.domain.member.entity.Member;
 import fc.be.app.domain.space.exception.SpaceException;
 import fc.be.app.domain.vote.entity.Vote;
 import jakarta.persistence.*;
@@ -103,5 +104,15 @@ public class Space {
         if (startDate == null || endDate == null || startDate.isAfter(endDate)) {
             throw new SpaceException(INVALID_START_DATE);
         }
+    }
+
+    public boolean isReadOnly(LocalDate requestDate) {
+        return requestDate.isAfter(this.endDate);
+    }
+
+    public boolean isBelong(Member member) {
+        return this.joinedMembers
+                .stream()
+                .anyMatch(joinedMember -> joinedMember.getMember().equals(member));
     }
 }

--- a/app/src/main/java/fc/be/app/domain/space/entity/Space.java
+++ b/app/src/main/java/fc/be/app/domain/space/entity/Space.java
@@ -44,7 +44,7 @@ public class Space {
     private List<Vote> voteSpaces;
 
     @OneToMany(mappedBy = "space")
-    private List<JoinedMember> joinedMembers;
+    private List<JoinedMember> joinedMembers = new ArrayList<>();
 
     @Builder
     private Space(String title, LocalDate startDate, LocalDate endDate) {

--- a/app/src/main/java/fc/be/app/domain/space/exception/SpaceErrorCode.java
+++ b/app/src/main/java/fc/be/app/domain/space/exception/SpaceErrorCode.java
@@ -10,7 +10,9 @@ public enum SpaceErrorCode {
     INVALID_START_DATE(400, "INVALID_START_DATE", "시작일자는 종료일자보다 늦거나 같아야 합니다."),
     SPACE_NOT_INVITE(404, "SPACE_NOT_INVITE", "해당 여행스페이스의 초대되어 있지 않습니다."),
     JOURNEY_NOT_FOUND(404, "JOURNEY_NOT_FOUND", "여행스페이스에 대한 여정정보가 존재하지 않습니다."),
-    NOT_JOINED_MEMBER(404, "NOT_JOINED_MEMBER", "여행스페이스에 속한 회원이 아닙니다.");
+    NOT_JOINED_MEMBER(404, "NOT_JOINED_MEMBER", "여행스페이스에 속한 회원이 아닙니다."),
+    SPACE_IS_READ_ONLY(400, "SPACE_IS_READ_ONLY", "여행스페이스가 읽기전용이기 때문에 수정할 수 없습니다.")
+    ;
 
     private final Integer responseCode;
     private final String title;

--- a/app/src/main/java/fc/be/app/domain/space/service/SpaceService.java
+++ b/app/src/main/java/fc/be/app/domain/space/service/SpaceService.java
@@ -87,8 +87,8 @@ public class SpaceService {
                 .orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND));
 
         if (space.getJourneys().isEmpty()) {
-            List<Journey> journeys = Journey.createJourneys(space.getStartDate(),
-                    space.getEndDate(),
+            List<Journey> journeys = Journey.createJourneys(updateRequest.startDate(),
+                    updateRequest.endDate(),
                     space);
             journeyRepository.saveAll(journeys);
         } else {
@@ -206,5 +206,15 @@ public class SpaceService {
 
     private static int countDaysBetween(LocalDate startDate, LocalDate endDate) {
         return Period.between(startDate, endDate).getDays();
+    }
+
+    private static void validateSpace(Space space, Member requestMember) {
+        if (space.isReadOnly(LocalDate.now())) {
+            throw new SpaceException(SPACE_IS_READ_ONLY);
+        }
+
+        if (!space.isBelong(requestMember)) {
+            throw new SpaceException(NOT_JOINED_MEMBER);
+        }
     }
 }

--- a/app/src/main/java/fc/be/app/domain/space/service/SpaceService.java
+++ b/app/src/main/java/fc/be/app/domain/space/service/SpaceService.java
@@ -208,13 +208,4 @@ public class SpaceService {
         return Period.between(startDate, endDate).getDays();
     }
 
-    private static void validateSpace(Space space, Member requestMember) {
-        if (space.isReadOnly(LocalDate.now())) {
-            throw new SpaceException(SPACE_IS_READ_ONLY);
-        }
-
-        if (!space.isBelong(requestMember)) {
-            throw new SpaceException(NOT_JOINED_MEMBER);
-        }
-    }
 }

--- a/app/src/main/java/fc/be/app/domain/vote/controller/VoteController.java
+++ b/app/src/main/java/fc/be/app/domain/vote/controller/VoteController.java
@@ -1,34 +1,53 @@
 package fc.be.app.domain.vote.controller;
 
+import fc.be.app.domain.vote.controller.dto.CandidateAddApiRequest;
 import fc.be.app.domain.vote.controller.dto.VoteCreateApiRequest;
 import fc.be.app.domain.vote.service.VoteManageUseCase;
 import fc.be.app.global.config.security.model.user.UserPrincipal;
 import fc.be.app.global.http.ApiResponse;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import static fc.be.app.domain.vote.service.VoteManageUseCase.*;
+import java.util.List;
+
+import static fc.be.app.domain.vote.service.VoteInfoQueryUseCase.VotesResponse;
+import static fc.be.app.domain.vote.service.VoteManageUseCase.CandidateAddRequest;
+import static fc.be.app.domain.vote.service.VoteManageUseCase.VoteCreateRequest;
 
 @RequestMapping("/votes")
 @RestController
 public class VoteController {
 
-    private final VoteManageUseCase voteCreateUseCase;
+    private final VoteManageUseCase voteManageUseCase;
 
-    public VoteController(VoteManageUseCase voteCreateUseCase) {
-        this.voteCreateUseCase = voteCreateUseCase;
+    public VoteController(VoteManageUseCase voteManageUseCase) {
+        this.voteManageUseCase = voteManageUseCase;
     }
 
     @PostMapping
     public ApiResponse<Long> createNewVote(@Valid VoteCreateApiRequest request,
                                            @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        return ApiResponse.created(voteCreateUseCase.createVote(
+        return ApiResponse.created(voteManageUseCase.createVote(
                 new VoteCreateRequest(
                         userPrincipal.id(),
                         request.spaceId(),
                         request.title())));
     }
+
+    @PostMapping("/{voteId}/candidates")
+    public ApiResponse<List<VotesResponse>> findVotesInSpace(@PathVariable Long voteId,
+                                                             CandidateAddApiRequest request,
+                                                             @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponse.ok(voteManageUseCase.addCandidate(
+                new CandidateAddRequest(
+                        userPrincipal.id(),
+                        voteId,
+                        request.datas())));
+    }
+
+
 }

--- a/app/src/main/java/fc/be/app/domain/vote/controller/VoteController.java
+++ b/app/src/main/java/fc/be/app/domain/vote/controller/VoteController.java
@@ -1,0 +1,34 @@
+package fc.be.app.domain.vote.controller;
+
+import fc.be.app.domain.vote.controller.dto.VoteCreateApiRequest;
+import fc.be.app.domain.vote.service.VoteManageUseCase;
+import fc.be.app.global.config.security.model.user.UserPrincipal;
+import fc.be.app.global.http.ApiResponse;
+import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static fc.be.app.domain.vote.service.VoteManageUseCase.*;
+
+@RequestMapping("/votes")
+@RestController
+public class VoteController {
+
+    private final VoteManageUseCase voteCreateUseCase;
+
+    public VoteController(VoteManageUseCase voteCreateUseCase) {
+        this.voteCreateUseCase = voteCreateUseCase;
+    }
+
+    @PostMapping
+    public ApiResponse<Long> createNewVote(@Valid VoteCreateApiRequest request,
+                                           @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        return ApiResponse.created(voteCreateUseCase.createVote(
+                new VoteCreateRequest(
+                        userPrincipal.id(),
+                        request.spaceId(),
+                        request.title())));
+    }
+}

--- a/app/src/main/java/fc/be/app/domain/vote/controller/dto/CandidateAddApiRequest.java
+++ b/app/src/main/java/fc/be/app/domain/vote/controller/dto/CandidateAddApiRequest.java
@@ -1,0 +1,12 @@
+package fc.be.app.domain.vote.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+import static fc.be.app.domain.vote.service.VoteManageUseCase.CandidateAddRequest.CandidateInfo;
+
+public record CandidateAddApiRequest(
+        @NotNull List<CandidateInfo> datas
+) {
+}

--- a/app/src/main/java/fc/be/app/domain/vote/controller/dto/VoteCreateApiRequest.java
+++ b/app/src/main/java/fc/be/app/domain/vote/controller/dto/VoteCreateApiRequest.java
@@ -1,0 +1,10 @@
+package fc.be.app.domain.vote.controller.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record VoteCreateApiRequest(
+        @NotNull Long spaceId,
+        @Size(min = 1, max = 15) String title
+) {
+}

--- a/app/src/main/java/fc/be/app/domain/vote/controller/dto/VoteCreateApiRequest.java
+++ b/app/src/main/java/fc/be/app/domain/vote/controller/dto/VoteCreateApiRequest.java
@@ -1,10 +1,11 @@
 package fc.be.app.domain.vote.controller.dto;
 
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public record VoteCreateApiRequest(
-        @NotNull Long spaceId,
+        @Positive @NotNull Long spaceId,
         @Size(min = 1, max = 15) String title
 ) {
 }

--- a/app/src/main/java/fc/be/app/domain/vote/dto/MemberProfile.java
+++ b/app/src/main/java/fc/be/app/domain/vote/dto/MemberProfile.java
@@ -1,0 +1,8 @@
+package fc.be.app.domain.vote.dto;
+
+public record MemberProfile(
+        Long id,
+        String nickName,
+        String profile
+) {
+}

--- a/app/src/main/java/fc/be/app/domain/vote/entity/Candidate.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/Candidate.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -20,11 +21,6 @@ public class Candidate {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("후보지 id")
     private Long id;
-
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    @Comment("작성자(FK)")
-    private Member member;
 
     @OneToMany(mappedBy = "candidate")
     @Comment("후보에 투표한 회원 id(FK)")
@@ -44,13 +40,21 @@ public class Candidate {
     private String tagline;
 
     @Builder
-    private Candidate(Long id, Member member, List<VotedMember> votedMember, Place place, Vote vote, String tagline) {
+    private Candidate(Long id, List<VotedMember> votedMember, Place place, Vote vote, String tagline) {
         this.id = id;
-        this.member = member;
         this.votedMember = votedMember;
         this.place = place;
         this.vote = vote;
         this.tagline = tagline;
+    }
+
+    public static Candidate of(Place place, Vote vote, String tagline) {
+        return Candidate.builder()
+                .place(place)
+                .vote(vote)
+                .tagline(tagline)
+                .votedMember(new ArrayList<>())
+                .build();
     }
 
     public void vote(Vote vote, Member member) {

--- a/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
@@ -4,12 +4,10 @@ import fc.be.app.domain.member.entity.Member;
 import fc.be.app.domain.space.entity.Space;
 import fc.be.app.domain.space.vo.VoteStatus;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.annotations.Comment;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -18,6 +16,7 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = false, of = {"id"})
 @Comment("투표")
 public class Vote {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Comment("투표 id")
@@ -47,8 +46,29 @@ public class Vote {
     @OneToMany(mappedBy = "vote")
     private List<VotedMember> votedMembers;
 
+    @Builder
+    private Vote(Long id, Space space, String title, VoteStatus status, Member owner, List<Candidate> candidates, List<VotedMember> votedMembers) {
+        this.id = id;
+        this.space = space;
+        this.title = title;
+        this.status = status;
+        this.owner = owner;
+        this.candidates = candidates;
+        this.votedMembers = votedMembers;
+    }
+
     public void addCandidate(Candidate candidate) {
         candidate.setVote(this);
         this.candidates.add(candidate);
+    }
+
+    public static Vote of(Space space, String title, Member owner) {
+        return Vote.builder()
+                .space(space)
+                .title(title)
+                .owner(owner)
+                .candidates(new ArrayList<>())
+                .votedMembers(new ArrayList<>())
+                .build();
     }
 }

--- a/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
@@ -62,6 +62,10 @@ public class Vote {
         this.candidates.add(candidate);
     }
 
+    public boolean isMax(int maxThreshold) {
+        return this.candidates.size() == maxThreshold;
+    }
+
     public static Vote of(Space space, String title, Member owner) {
         return Vote.builder()
                 .space(space)

--- a/app/src/main/java/fc/be/app/domain/vote/exception/VoteErrorCode.java
+++ b/app/src/main/java/fc/be/app/domain/vote/exception/VoteErrorCode.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum VoteErrorCode {
     VOTE_NOT_FOUND(404, "VOTE_NOT_FOUND", "투표 정보가 존재하지 않습니다."),
+    CANDIDATE_IS_MAX(400, "CANDIDATE_IS_MAX", "후보는 15개 이상 등록할 수 없습니다.")
     ;
 
     private final Integer responseCode;

--- a/app/src/main/java/fc/be/app/domain/vote/exception/VoteErrorCode.java
+++ b/app/src/main/java/fc/be/app/domain/vote/exception/VoteErrorCode.java
@@ -1,0 +1,15 @@
+package fc.be.app.domain.vote.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum VoteErrorCode {
+    VOTE_NOT_FOUND(404, "VOTE_NOT_FOUND", "투표 정보가 존재하지 않습니다."),
+    ;
+
+    private final Integer responseCode;
+    private final String title;
+    private final String detail;
+}

--- a/app/src/main/java/fc/be/app/domain/vote/exception/VoteException.java
+++ b/app/src/main/java/fc/be/app/domain/vote/exception/VoteException.java
@@ -1,0 +1,10 @@
+package fc.be.app.domain.vote.exception;
+
+import fc.be.app.global.exception.BizException;
+
+public class VoteException extends BizException {
+    public VoteException(VoteErrorCode errorCode) {
+        super(errorCode.getTitle(), errorCode.getDetail(), errorCode.getResponseCode());
+    }
+
+}

--- a/app/src/main/java/fc/be/app/domain/vote/repository/VoteRepository.java
+++ b/app/src/main/java/fc/be/app/domain/vote/repository/VoteRepository.java
@@ -1,0 +1,13 @@
+package fc.be.app.domain.vote.repository;
+
+import fc.be.app.domain.vote.entity.Vote;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface VoteRepository extends JpaRepository<Vote, Long> {
+
+    @Query("select v from Vote v where v.space.id = :spaceId")
+    List<Vote> findAllBySpaceId(Long spaceId);
+}

--- a/app/src/main/java/fc/be/app/domain/vote/repository/VoteRepositoryCustom.java
+++ b/app/src/main/java/fc/be/app/domain/vote/repository/VoteRepositoryCustom.java
@@ -1,0 +1,12 @@
+package fc.be.app.domain.vote.repository;
+
+import fc.be.app.domain.vote.repository.dto.VotesQueryResponse;
+
+import java.util.List;
+
+public interface VoteRepositoryCustom {
+
+    VotesQueryResponse findByVoteId(Long id);
+
+    List<VotesQueryResponse> findBySpaceId(Long spaceId);
+}

--- a/app/src/main/java/fc/be/app/domain/vote/repository/dto/VoteQueryResponse.java
+++ b/app/src/main/java/fc/be/app/domain/vote/repository/dto/VoteQueryResponse.java
@@ -1,0 +1,13 @@
+package fc.be.app.domain.vote.repository.dto;
+
+import fc.be.app.domain.space.vo.VoteStatus;
+
+public class VoteQueryResponse {
+    private Long voteId;
+    private String title;
+    private String tagline;
+    private VoteStatus voteStatus;
+    private Long ownerId;
+    private String ownerNickname;
+    private String ownerImage;
+}

--- a/app/src/main/java/fc/be/app/domain/vote/repository/dto/VotesQueryResponse.java
+++ b/app/src/main/java/fc/be/app/domain/vote/repository/dto/VotesQueryResponse.java
@@ -1,0 +1,17 @@
+package fc.be.app.domain.vote.repository.dto;
+
+import fc.be.app.domain.space.vo.VoteStatus;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class VotesQueryResponse {
+    private Long voteId;
+    private String title;
+    private VoteStatus voteStatus;
+    private Long ownerId;
+    private String ownerNickname;
+    private String ownerImage;
+    private List<String> votedMemberProfiles;
+}

--- a/app/src/main/java/fc/be/app/domain/vote/service/VoteInfoQueryUseCase.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/VoteInfoQueryUseCase.java
@@ -1,0 +1,65 @@
+package fc.be.app.domain.vote.service;
+
+import fc.be.app.domain.space.vo.VoteStatus;
+import fc.be.app.domain.vote.dto.MemberProfile;
+import fc.be.app.domain.vote.entity.Candidate;
+
+import java.util.List;
+
+/**
+ * 투표의 전체적인 정보를 쿼리할 수 있는 API 입니다.
+ */
+public interface VoteInfoQueryUseCase {
+
+    VotesResponse findAllVotesInSpace(Long spaceId);
+
+    VoteResponse findByVoteId(Long voteId);
+
+    VoteResultResponse findResultByVoteId(Long voteId);
+
+    record VoteResponse(
+            Long id,
+            String title,
+            MemberProfile ownerProfile,
+            List<CandidateResponse> candidates
+    ) {
+    }
+
+    record VotesResponse(
+            List<VotesResponseElement> data
+    ) {
+
+    }
+
+    record VotesResponseElement(
+            Long voteId,
+            String title,
+            VoteStatus voteStatus,
+            MemberProfile ownerProfile,
+            List<MemberProfile> votedMemberProfiles
+    ) {
+
+    }
+
+    record CandidateResponse(
+            Long id,
+            Integer placeId,
+            String placeName,
+            String category,
+            String tagline
+    ) {
+
+        public static CandidateResponse of(Candidate candidate) {
+            return new CandidateResponse(
+                    candidate.getId(),
+                    candidate.getPlace().getId(),
+                    candidate.getPlace().getThumbnail(),
+                    candidate.getPlace().getCategory(),
+                    candidate.getTagline());
+        }
+    }
+
+    record VoteResultResponse() {
+
+    }
+}

--- a/app/src/main/java/fc/be/app/domain/vote/service/VoteManageUseCase.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/VoteManageUseCase.java
@@ -1,8 +1,14 @@
 package fc.be.app.domain.vote.service;
 
+import java.util.List;
+
 public interface VoteManageUseCase {
 
     Long createVote(VoteCreateRequest request);
+
+
+    VoteInfoQueryUseCase.VoteResponse addCandidate(CandidateAddRequest request);
+
 
     record VoteCreateRequest(
             Long memberId,
@@ -10,5 +16,18 @@ public interface VoteManageUseCase {
             String title
     ) {
 
+    }
+
+    record CandidateAddRequest(
+            Long memberId,
+            Long voteId,
+            List<CandidateInfo> candidateInfo
+    ) {
+        public record CandidateInfo(
+                Integer placeId,
+                String tagline
+        ) {
+
+        }
     }
 }

--- a/app/src/main/java/fc/be/app/domain/vote/service/VoteManageUseCase.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/VoteManageUseCase.java
@@ -1,0 +1,14 @@
+package fc.be.app.domain.vote.service;
+
+public interface VoteManageUseCase {
+
+    Long createVote(VoteCreateRequest request);
+
+    record VoteCreateRequest(
+            Long memberId,
+            Long spaceId,
+            String title
+    ) {
+
+    }
+}

--- a/app/src/main/java/fc/be/app/domain/vote/service/VotingUseCase.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/VotingUseCase.java
@@ -1,0 +1,16 @@
+package fc.be.app.domain.vote.service;
+
+/**
+ * 투표 기능을 수행하는 API 입니다.
+ */
+public interface VotingUseCase {
+
+    void vote(VoteRequest request);
+
+    record VoteRequest(
+            Long voteId,
+            Long memberId,
+            Long candidateId
+    ) {
+    }
+}

--- a/app/src/main/java/fc/be/app/domain/vote/service/service/VoteManageService.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/service/VoteManageService.java
@@ -3,33 +3,50 @@ package fc.be.app.domain.vote.service.service;
 import fc.be.app.domain.member.entity.Member;
 import fc.be.app.domain.member.exception.MemberException;
 import fc.be.app.domain.member.repository.MemberRepository;
+import fc.be.app.domain.place.Place;
+import fc.be.app.domain.place.repository.PlaceRepository;
 import fc.be.app.domain.space.entity.Space;
 import fc.be.app.domain.space.exception.SpaceException;
 import fc.be.app.domain.space.repository.SpaceRepository;
+import fc.be.app.domain.vote.dto.MemberProfile;
+import fc.be.app.domain.vote.entity.Candidate;
 import fc.be.app.domain.vote.entity.Vote;
+import fc.be.app.domain.vote.exception.VoteErrorCode;
+import fc.be.app.domain.vote.exception.VoteException;
 import fc.be.app.domain.vote.repository.VoteRepository;
 import fc.be.app.domain.vote.service.VoteManageUseCase;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
 
 import static fc.be.app.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
 import static fc.be.app.domain.space.exception.SpaceErrorCode.*;
+import static fc.be.app.domain.vote.exception.VoteErrorCode.CANDIDATE_IS_MAX;
+import static fc.be.app.domain.vote.service.VoteInfoQueryUseCase.CandidateResponse;
+import static fc.be.app.domain.vote.service.VoteInfoQueryUseCase.VoteResponse;
+import static fc.be.app.domain.vote.service.VoteManageUseCase.CandidateAddRequest.CandidateInfo;
 
 @Service
 public class VoteManageService implements VoteManageUseCase {
 
+    private static final int CANDIDATE_COUNT_THRESHOLD = 15;
+
     private final VoteRepository voteRepository;
     private final SpaceRepository spaceRepository;
     private final MemberRepository memberRepository;
+    private final PlaceRepository placeRepository;
 
     public VoteManageService(VoteRepository voteRepository,
                              SpaceRepository spaceRepository,
-                             MemberRepository memberRepository) {
+                             MemberRepository memberRepository,
+                             PlaceRepository placeRepository) {
         this.voteRepository = voteRepository;
         this.spaceRepository = spaceRepository;
         this.memberRepository = memberRepository;
+        this.placeRepository = placeRepository;
     }
 
     @Transactional
@@ -57,5 +74,61 @@ public class VoteManageService implements VoteManageUseCase {
         if (!space.isBelong(requestMember)) {
             throw new SpaceException(NOT_JOINED_MEMBER);
         }
+    }
+
+    @Override
+    public VoteResponse addCandidate(CandidateAddRequest request) {
+        final Member requestMember = memberRepository.findById(request.memberId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        Vote vote = voteRepository.findById(request.voteId())
+                .orElseThrow(() -> new VoteException(VoteErrorCode.VOTE_NOT_FOUND));
+
+        final Space space = vote.getSpace();
+
+        validateSpace(space, requestMember);
+        validateVote(vote);
+
+        List<Integer> placeIds = extractPlaceIdsFromRequest(request);
+
+        List<Place> places = placeRepository.findAllById(placeIds);
+
+        for (Place place : places) {
+            Optional<String> first = findMatchTagline(request, place);
+
+            vote.addCandidate(Candidate.of(place, vote, first.orElseGet(() -> "")));
+        }
+
+        // TODO : Sending a new vote creation event to all members of the space
+        return new VoteResponse(
+                vote.getId(),
+                vote.getTitle(),
+                new MemberProfile(
+                        vote.getOwner().getId(),
+                        vote.getOwner().getNickname(),
+                        vote.getOwner().getProfile()
+                ),
+                vote.getCandidates().stream()
+                        .map(CandidateResponse::of)
+                        .toList());
+    }
+
+    private static void validateVote(Vote vote) {
+        if (vote.isMax(CANDIDATE_COUNT_THRESHOLD)) {
+            throw new VoteException(CANDIDATE_IS_MAX);
+        }
+    }
+
+    private List<Integer> extractPlaceIdsFromRequest(CandidateAddRequest request) {
+        return request.candidateInfo().stream()
+                .map(CandidateInfo::placeId)
+                .toList();
+    }
+
+    private Optional<String> findMatchTagline(CandidateAddRequest request, Place place) {
+        return request.candidateInfo().stream()
+                .filter(info -> info.placeId().equals(place.getId()))
+                .map(CandidateInfo::tagline)
+                .findFirst();
     }
 }

--- a/app/src/main/java/fc/be/app/domain/vote/service/service/VoteManageService.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/service/VoteManageService.java
@@ -1,0 +1,61 @@
+package fc.be.app.domain.vote.service.service;
+
+import fc.be.app.domain.member.entity.Member;
+import fc.be.app.domain.member.exception.MemberException;
+import fc.be.app.domain.member.repository.MemberRepository;
+import fc.be.app.domain.space.entity.Space;
+import fc.be.app.domain.space.exception.SpaceException;
+import fc.be.app.domain.space.repository.SpaceRepository;
+import fc.be.app.domain.vote.entity.Vote;
+import fc.be.app.domain.vote.repository.VoteRepository;
+import fc.be.app.domain.vote.service.VoteManageUseCase;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+import static fc.be.app.domain.member.exception.MemberErrorCode.MEMBER_NOT_FOUND;
+import static fc.be.app.domain.space.exception.SpaceErrorCode.*;
+
+@Service
+public class VoteManageService implements VoteManageUseCase {
+
+    private final VoteRepository voteRepository;
+    private final SpaceRepository spaceRepository;
+    private final MemberRepository memberRepository;
+
+    public VoteManageService(VoteRepository voteRepository,
+                             SpaceRepository spaceRepository,
+                             MemberRepository memberRepository) {
+        this.voteRepository = voteRepository;
+        this.spaceRepository = spaceRepository;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public Long createVote(VoteCreateRequest request) {
+        final Member requestMember = memberRepository.findById(request.memberId())
+                .orElseThrow(() -> new MemberException(MEMBER_NOT_FOUND));
+
+        final Space space = spaceRepository.findById(request.spaceId())
+                .orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND));
+
+        validateSpace(space, requestMember);
+
+        Vote savedVote = voteRepository
+                .save(Vote.of(space, request.title(), requestMember));
+
+        // TODO : Sending a new vote creation event to all members of the space
+        return savedVote.getId();
+    }
+
+    private static void validateSpace(Space space, Member requestMember) {
+        if (space.isReadOnly(LocalDate.now())) {
+            throw new SpaceException(SPACE_IS_READ_ONLY);
+        }
+
+        if (!space.isBelong(requestMember)) {
+            throw new SpaceException(NOT_JOINED_MEMBER);
+        }
+    }
+}


### PR DESCRIPTION
## 변경사항

- 여행스페이스 조회 시 초대멤버 정보 함께 조회기능 구현 
- select-places URL 수정 (Rest 규격에 맞지않은것 같고 후에 권한에 대한 일괄처리를 위해 수정) 
- 최근여행스페이스 정보 호출에 대한 API 명세작업을 위해 빈 껍데기 컨트롤러 작성(후에 이슈작업예정)

### Issue Link - #86 

-----

## 체크리스트

리뷰 요청 전에 확인해야 할 사항들을 나열해주세요.

- [ ] 내 코드를 스스로 검토했나요?
- [ ] 핵심 기능에 대해 충분한 테스트를 수행했나요?
- [ ] 분석이 필요한가요?

