### PR TITLE
[Bugfix] ApiResponse에 제네릭을 추가한다.

### DIFF
--- a/app/src/main/java/fc/be/app/domain/review/controller/ReviewController.java
+++ b/app/src/main/java/fc/be/app/domain/review/controller/ReviewController.java
@@ -22,7 +22,7 @@ public class ReviewController {
     }
 
     @PatchMapping
-    public ApiResponse<ReviewCreateResponse> editReview(@Valid @RequestBody ReviewEditRequest reviewEditRequest) {
+    public ApiResponse<ReviewEditResponse> editReview(@Valid @RequestBody ReviewEditRequest reviewEditRequest) {
         return ApiResponse.ok(reviewService.editReview(reviewEditRequest));
     }
 

--- a/app/src/main/java/fc/be/app/global/http/ApiResponse.java
+++ b/app/src/main/java/fc/be/app/global/http/ApiResponse.java
@@ -11,19 +11,19 @@ public record ApiResponse<T>(
     private static final HttpStatus CREATED = HttpStatus.CREATED;
     private static final String DEFAULT_MESSAGE = "SUCCESS";
 
-    public static ApiResponse ok() {
-        return new ApiResponse(OK.value(), DEFAULT_MESSAGE, null);
+    public static ApiResponse<Void> ok() {
+        return new ApiResponse<>(OK.value(), DEFAULT_MESSAGE, null);
     }
 
-    public static <T> ApiResponse ok(T data) {
-        return new ApiResponse(OK.value(), DEFAULT_MESSAGE, data);
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(OK.value(), DEFAULT_MESSAGE, data);
     }
 
-    public static ApiResponse created() {
-        return new ApiResponse(CREATED.value(), DEFAULT_MESSAGE, null);
+    public static ApiResponse<Void> created() {
+        return new ApiResponse<>(CREATED.value(), DEFAULT_MESSAGE, null);
     }
 
-    public static <T> ApiResponse created(T data) {
-        return new ApiResponse(CREATED.value(), DEFAULT_MESSAGE, data);
+    public static <T> ApiResponse<T> created(T data) {
+        return new ApiResponse<>(CREATED.value(), DEFAULT_MESSAGE, data);
     }
 }


### PR DESCRIPTION
## 변경사항
- 정적팩토리 메서드의 리턴타입에 제네릭이 누락되어 문제가 raw type warning이 발생하였습니다. 제네릭을 추가함으로써 간단하게 해결을 할 수 있습니다.
- 정적팩토리 메서드에 제네릭 추가

### Issue Link - #103