### PR TITLE
[Build] Gradle 내 Swaggerhub 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id 'java'
+    id 'org.springdoc.openapi-gradle-plugin' version '1.8.0'
+    id 'io.swagger.swaggerhub' version '1.1.0'
+}
+
 jar {
     enabled = false
 }
@@ -39,6 +45,9 @@ dependencies {
     // https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-s3
     implementation group: 'com.amazonaws', name: 'aws-java-sdk-s3', version: '1.12.637'
 
+    // documentation
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:+'
+
     // test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
@@ -55,4 +64,27 @@ tasks.withType(JavaCompile).configureEach {
 
 clean.doLast {
     file(querydslDir).deleteDir()
+}
+
+openApi {
+    apiDocsUrl.set("http://localhost:8080/v3/api-docs.yaml")
+    outputDir.set(file("$buildDir/docs"))
+    outputFileName.set("swagger.yaml")
+    waitTimeInSeconds.set(10)
+    customBootRun {
+        args.set(["--spring.profiles.active=dev"])
+    }
+}
+
+import java.text.SimpleDateFormat
+
+swaggerhubUpload {
+    def dateVersion = new SimpleDateFormat('yyyy-MM-dd').format(new Date())
+
+    api 'trip-vote_api'
+    owner 'strong-potato'
+    version dateVersion
+    format 'yaml'
+    inputFile "$buildDir/docs/swagger.yaml"
+    token System.getenv("SWAGGERHUB_API_KEY")
 }


### PR DESCRIPTION
## 변경사항

이제 원클릭으로 명세서를 갱신할 수 있습니다.

버전은 날짜 `yyyy-MM-dd` 를 기준으로 매겨집니다.

※ `application-common.yml` 에 반드시! 아래의 값이 추가되어야 합니다.
```yaml
springdoc:
  use-fqn: true
```

Swaggerhub API 키는 별도로 공유하겠습니다 🙌

### Issue Link - #53

-----

## 체크리스트

리뷰 요청 전에 확인해야 할 사항들을 나열해주세요.

- [x] 명세서가 생성되나요?
- [x] 명세서 업로드가 되나요?

-----

## 참고
https://app.swaggerhub.com/apis-docs/strong-potato/trip-vote_api

사용법

![image](https://github.com/Strong-Potato/TripVote-BE/assets/26517061/ff930887-9497-4e41-9cd8-604645caaa25)
