### PR TITLE
[Feat] local용 Cookie 발급

### DIFF
--- a/app/src/main/java/fc/be/app/global/config/security/filter/JwtAuthenticationFilter.java
+++ b/app/src/main/java/fc/be/app/global/config/security/filter/JwtAuthenticationFilter.java
@@ -90,6 +90,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             TokenPair newTokenPair = (TokenPair) jwtAuthToken.getCredentials();
             if (newTokenPair.isRegenerated()) {
                 CookieUtil.addCookie(response, tokenProperties.getAccessTokenName(), newTokenPair.accessToken(), Integer.parseInt(tokenProperties.getAccessTokenCookieExpireTime()));
+                CookieUtil.addCookieForLocal(response, tokenProperties.getAccessTokenName(), newTokenPair.accessToken(), Integer.parseInt(tokenProperties.getAccessTokenCookieExpireTime()));
             }
         }
     }

--- a/app/src/main/java/fc/be/app/global/config/security/handler/LoginAuthenticationSuccessHandler.java
+++ b/app/src/main/java/fc/be/app/global/config/security/handler/LoginAuthenticationSuccessHandler.java
@@ -50,9 +50,11 @@ public class LoginAuthenticationSuccessHandler implements AuthenticationSuccessH
             throw new InternalAuthenticationServiceException(ex.getMessage(), ex);
         }
         CookieUtil.addCookie(response, tokenProperties.getAccessTokenName(), accessToken, Integer.parseInt(tokenProperties.getAccessTokenCookieExpireTime()));
+        CookieUtil.addCookieForLocal(response, tokenProperties.getAccessTokenName(), accessToken, Integer.parseInt(tokenProperties.getAccessTokenCookieExpireTime()));
 
         String refreshToken = refreshTokenService.refresh(accessToken, principal, (AuthenticationDetails) loginAuthentication.getDetails());
         CookieUtil.addCookie(response, tokenProperties.getRefreshTokenName(), refreshToken, Integer.parseInt(tokenProperties.getRefreshTokenCookieExpireTime()));
+        CookieUtil.addCookieForLocal(response, tokenProperties.getRefreshTokenName(), refreshToken, Integer.parseInt(tokenProperties.getRefreshTokenCookieExpireTime()));
 
         response.setStatus(HttpStatus.OK.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/app/src/main/java/fc/be/app/global/config/security/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/app/src/main/java/fc/be/app/global/config/security/handler/OAuth2AuthenticationSuccessHandler.java
@@ -73,9 +73,11 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
             throw new InternalAuthenticationServiceException(ex.getMessage(), ex);
         }
         CookieUtil.addCookie(response, tokenProperties.getAccessTokenName(), accessToken, Integer.parseInt(tokenProperties.getAccessTokenExpireTime()));
+        CookieUtil.addCookieForLocal(response, tokenProperties.getAccessTokenName(), accessToken, Integer.parseInt(tokenProperties.getAccessTokenExpireTime()));
 
         String refreshToken = refreshTokenService.refresh(accessToken, userPrincipal, (AuthenticationDetails) oauth2Authentication.getDetails());
         CookieUtil.addCookie(response, tokenProperties.getRefreshTokenName(), refreshToken, Integer.parseInt(tokenProperties.getRefreshTokenCookieExpireTime()));
+        CookieUtil.addCookieForLocal(response, tokenProperties.getRefreshTokenName(), refreshToken, Integer.parseInt(tokenProperties.getRefreshTokenCookieExpireTime()));
 
         response.sendRedirect("https://tripvote.site");
     }

--- a/app/src/main/java/fc/be/app/global/util/CookieUtil.java
+++ b/app/src/main/java/fc/be/app/global/util/CookieUtil.java
@@ -23,10 +23,21 @@ public class CookieUtil {
     public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
-        //cookie.setDomain(HOST);
+        cookie.setDomain("tripvote.site");
         cookie.setHttpOnly(true);
         cookie.setSecure(true);
         cookie.setAttribute("SameSite", "Lax");
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    // TODO: Remove before product
+    public static void addCookieForLocal(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setAttribute("SameSite", "None");
         cookie.setMaxAge(maxAge);
         response.addCookie(cookie);
     }


### PR DESCRIPTION
## 변경사항

Front 개발자가 로컬에서 Cookie를 받아볼 수 있도록 동일한 쿠키를 두 개씩 발급합니다.
향후 배포단계(main에 merge할 때)에는 걷어내야 하므로 TODO로 작성해두었습니다.
Front 개발자가 로컬에서 잘 받아볼 수 있는 것도 확인했습니다.

### Issue Link - #132 


## 체크리스트

- [x] 내 코드를 스스로 검토했나요?
- [x] 핵심 기능에 대해 충분한 테스트를 수행했나요?

