### PR TITLE
[Feat] 여행스페이스 내 타이틀 변경기능 요구사항 변경 적용

### DIFF
--- a/app/src/main/java/fc/be/app/domain/space/controller/SpaceController.java
+++ b/app/src/main/java/fc/be/app/domain/space/controller/SpaceController.java
@@ -4,10 +4,7 @@ import fc.be.app.domain.space.dto.request.DateUpdateRequest;
 import fc.be.app.domain.space.dto.request.SelectedPlaceRequest;
 import fc.be.app.domain.space.dto.request.SelectedPlacesRequest;
 import fc.be.app.domain.space.dto.request.TitleUpdateRequest;
-import fc.be.app.domain.space.dto.response.JourneyResponse;
-import fc.be.app.domain.space.dto.response.JourneysResponse;
-import fc.be.app.domain.space.dto.response.SpaceIdResponse;
-import fc.be.app.domain.space.dto.response.SpaceResponse;
+import fc.be.app.domain.space.dto.response.*;
 import fc.be.app.domain.space.service.SpaceService;
 import fc.be.app.global.config.security.model.user.UserPrincipal;
 import fc.be.app.global.http.ApiResponse;
@@ -94,5 +91,10 @@ public class SpaceController {
     @GetMapping("/recent")
     public ApiResponse<SpaceIdResponse> recentSpace(@AuthenticationPrincipal UserPrincipal userPrincipal) {
         return ApiResponse.ok(spaceTokenService.getRecentSpace(userPrincipal.id()));
+    }
+
+    @GetMapping("/city")
+    public ApiResponse<CitiesResponse> getCities() {
+        return ApiResponse.ok(spaceService.getCities());
     }
 }

--- a/app/src/main/java/fc/be/app/domain/space/dto/request/TitleUpdateRequest.java
+++ b/app/src/main/java/fc/be/app/domain/space/dto/request/TitleUpdateRequest.java
@@ -1,12 +1,16 @@
 package fc.be.app.domain.space.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
+
+import java.util.List;
 
 @Builder
 public record TitleUpdateRequest(
-        @NotBlank(message = "타이틀은 빈값을 넣을 수 없습니다.")
-        String title
+        @NotNull
+        @Size(min = 1)
+        List<String> cities
 ) {
 
 }

--- a/app/src/main/java/fc/be/app/domain/space/dto/response/CitiesResponse.java
+++ b/app/src/main/java/fc/be/app/domain/space/dto/response/CitiesResponse.java
@@ -1,0 +1,27 @@
+package fc.be.app.domain.space.dto.response;
+
+import fc.be.app.domain.space.entity.Journey;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CitiesResponse(
+        List<CityResponse> cities
+) {
+
+    public static CitiesResponse of(List<CityResponse> cities) {
+        return CitiesResponse.builder()
+                .cities(cities)
+                .build();
+    }
+
+    @Builder
+    public record CityResponse(
+            String cityName,
+            String imageUrl
+    ){
+
+    }
+
+}

--- a/app/src/main/java/fc/be/app/domain/space/dto/response/SpaceResponse.java
+++ b/app/src/main/java/fc/be/app/domain/space/dto/response/SpaceResponse.java
@@ -14,6 +14,8 @@ public record SpaceResponse(
         String title,
         LocalDate startDate,
         LocalDate endDate,
+        String city,
+        String thumbnail,
         List<MemberInfo> members
 ) {
     public static SpaceResponse of(Space space) {
@@ -34,6 +36,8 @@ public record SpaceResponse(
                         .title(space.getTitle())
                         .startDate(space.getStartDate())
                         .endDate(space.getEndDate())
+                        .city(space.getCity() != null ? String.join(",", space.getCity()) : null)
+                        .thumbnail(space.getCityThumbnail())
                         .members(memberInfos)
                         .build();
     }

--- a/app/src/main/java/fc/be/app/domain/space/entity/Space.java
+++ b/app/src/main/java/fc/be/app/domain/space/entity/Space.java
@@ -2,7 +2,9 @@ package fc.be.app.domain.space.entity;
 
 import fc.be.app.domain.member.entity.Member;
 import fc.be.app.domain.space.exception.SpaceException;
+import fc.be.app.domain.space.vo.KoreanCity;
 import fc.be.app.domain.vote.entity.Vote;
+import fc.be.app.global.util.DelimiterConverter;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -37,6 +39,10 @@ public class Space {
     @Comment("종료일")
     private LocalDate endDate;
 
+    @Convert(converter = DelimiterConverter.class)
+    @Comment("선택된도시리스트")
+    private List<String> city;
+
     @OneToMany(mappedBy = "space")
     private List<Journey> journeys;
 
@@ -53,15 +59,18 @@ public class Space {
         this.endDate = endDate;
     }
 
-    public static Space create() {
+    public static Space create(String nickname) {
         return Space.builder()
+                .title(nickname + "의 여행")
                 .build();
     }
 
     public void updateByTitle(String title) {
-        if (title != null && !title.isEmpty()) {
-            this.title = title;
-        }
+        this.title = title;
+    }
+
+    public void updateByCity(List<String> cities) {
+        this.city = cities;
     }
 
     public void updateByDates(LocalDate startDate, LocalDate endDate) {
@@ -117,4 +126,13 @@ public class Space {
                 .stream()
                 .anyMatch(joinedMember -> !joinedMember.isLeftSpace() && joinedMember.getMember().equals(member));
     }
+
+    public String getCityThumbnail() {
+        if (this.city == null || this.city.isEmpty()) {
+            return null;
+        }
+
+        return KoreanCity.getByCityName(this.city.get(0));
+    }
+
 }

--- a/app/src/main/java/fc/be/app/domain/space/exception/SpaceErrorCode.java
+++ b/app/src/main/java/fc/be/app/domain/space/exception/SpaceErrorCode.java
@@ -11,7 +11,8 @@ public enum SpaceErrorCode {
     JOURNEY_NOT_FOUND(404, "JOURNEY_NOT_FOUND", "여행스페이스에 대한 여정정보가 존재하지 않습니다."),
     NOT_JOINED_MEMBER(404, "NOT_JOINED_MEMBER", "여행스페이스에 속한 회원이 아닙니다."),
     SPACE_IS_READ_ONLY(400, "SPACE_IS_READ_ONLY", "여행스페이스가 읽기전용이기 때문에 수정할 수 없습니다."),
-    SPACE_MAX_COUNT_OVER(400, "SPACE_MAX_COUNT_OVER", "여행스페이스 생성 최대 개수를 초과하셨습니다.");
+    SPACE_MAX_COUNT_OVER(400, "SPACE_MAX_COUNT_OVER", "여행스페이스 생성 최대 개수를 초과하셨습니다."),
+    NO_SUCH_CITY(404, "NO_SUCH_CITY", "해당 도시가 없습니다.");
 
     private final Integer responseCode;
     private final String title;

--- a/app/src/main/java/fc/be/app/domain/space/service/SpaceService.java
+++ b/app/src/main/java/fc/be/app/domain/space/service/SpaceService.java
@@ -10,10 +10,7 @@ import fc.be.app.domain.space.dto.request.DateUpdateRequest;
 import fc.be.app.domain.space.dto.request.SelectedPlaceRequest;
 import fc.be.app.domain.space.dto.request.SelectedPlacesRequest;
 import fc.be.app.domain.space.dto.request.TitleUpdateRequest;
-import fc.be.app.domain.space.dto.response.JourneyResponse;
-import fc.be.app.domain.space.dto.response.JourneysResponse;
-import fc.be.app.domain.space.dto.response.SpaceResponse;
-import fc.be.app.domain.space.dto.response.SpacesResponse;
+import fc.be.app.domain.space.dto.response.*;
 import fc.be.app.domain.space.entity.JoinedMember;
 import fc.be.app.domain.space.entity.Journey;
 import fc.be.app.domain.space.entity.SelectedPlace;
@@ -23,6 +20,7 @@ import fc.be.app.domain.space.repository.JoinedMemberRepository;
 import fc.be.app.domain.space.repository.JourneyRepository;
 import fc.be.app.domain.space.repository.SelectedPlaceRepository;
 import fc.be.app.domain.space.repository.SpaceRepository;
+import fc.be.app.domain.space.vo.KoreanCity;
 import fc.be.app.domain.space.vo.SpaceType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -62,7 +60,7 @@ public class SpaceService {
             throw new SpaceException(SPACE_MAX_COUNT_OVER);
         }
 
-        Space savedSpace = spaceRepository.save(Space.create());
+        Space savedSpace = spaceRepository.save(Space.create(member.getNickname()));
 
         JoinedMember joinedMember = JoinedMember.create(savedSpace, member);
         joinedMemberRepository.save(joinedMember);
@@ -92,7 +90,7 @@ public class SpaceService {
 
         validateSpace(space, requestMember, currentDate);
 
-        space.updateByTitle(updateRequest.title());
+        space.updateByCity(updateRequest.cities());
         return SpaceResponse.of(space);
     }
 
@@ -264,4 +262,9 @@ public class SpaceService {
         }
     }
 
+    public CitiesResponse getCities() {
+        List<CitiesResponse.CityResponse> cityList = KoreanCity.getCityList();
+
+        return CitiesResponse.of(cityList);
+    }
 }

--- a/app/src/main/java/fc/be/app/domain/space/service/SpaceTokenService.java
+++ b/app/src/main/java/fc/be/app/domain/space/service/SpaceTokenService.java
@@ -76,6 +76,10 @@ public class SpaceTokenService {
         Space space = spaceRepository.findById(spaceId)
                 .orElseThrow(() -> new SpaceException(SPACE_NOT_FOUND));
 
+        if(space.getEndDate() == null){
+            return false;
+        }
+
         return space.isReadOnly(currentDate);
     }
 }

--- a/app/src/main/java/fc/be/app/domain/space/vo/KoreanCity.java
+++ b/app/src/main/java/fc/be/app/domain/space/vo/KoreanCity.java
@@ -1,0 +1,60 @@
+package fc.be.app.domain.space.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static fc.be.app.domain.space.dto.response.CitiesResponse.CityResponse;
+
+@Getter
+@AllArgsConstructor
+public enum KoreanCity {
+
+    DOMESTIC("국내", "https://images.unsplash.com/photo-1584664711948-c29ed327a614?q=80&w=3870&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    GAPYEONG("가평", "https://images.unsplash.com/photo-1644765687004-ab56dcb98dd5?q=80&w=3269&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    YANGPYEONG("양평", "https://img1.daumcdn.net/thumb/R1280x0/?fname=http://t1.daumcdn.net/brunch/service/user/1jPF/image/VzFSWaNSbdecQ6NU-iP9f7-HzAU.jpg"),
+    GANGNEUNG("강릉", "https://images.unsplash.com/photo-1621044332832-717d5d986ab7?q=80&w=1740&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    SOKCHO("속초", "https://images.unsplash.com/photo-1663949405336-e142646d9fbd?q=80&w=2697&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    YANGYANG("양양", "https://images.unsplash.com/photo-1591797761976-4c97d23a191e?q=80&w=1760&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    GYEONGJU("경주", "https://images.unsplash.com/photo-1656980593245-b54c8c0828f0?q=80&w=1740&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    BUSAN("부산", "https://images.unsplash.com/photo-1578037571214-25e07ed4a487?q=80&w=2808&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    YEOSU("여수", "https://images.unsplash.com/photo-1651375562199-65caae096ace?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    SUNGCHEON("순천", "https://images.unsplash.com/photo-1695454247140-859c0047274d?q=80&w=3000&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    INCHEON("인천", "https://images.unsplash.com/photo-1647699351838-05a5c17baac4?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    JEONJU("전주", "https://images.unsplash.com/photo-1544827503-673e2a2c4c00?w=800&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8JUVDJUEwJTg0JUVDJUEzJUJDfGVufDB8fDB8fHww"),
+    JEJU("제주", "https://images.unsplash.com/photo-1579169326371-ccb4e63f7889?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    CHUNCHEON("춘천", "https://images.unsplash.com/photo-1622628036982-f82aa2fd4fc5?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    TONGYEONG("통영", "https://images.unsplash.com/photo-1606666476184-7d2940f2db90?q=80&w=2748&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    GEOJE("거제", "https://images.unsplash.com/photo-1672063937910-d3974ad9bd77?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    NAMHAE("남해", "https://images.unsplash.com/photo-1607898668108-0aa26c578fe3?q=80&w=2675&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"),
+    ANDONG("안동", "https://images.unsplash.com/photo-1503932860988-56df256a6c5f?q=80&w=2670&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D");
+
+    private final String cityName;
+    private final String imageUrl;
+
+    public static String getByCityName(String cityName) {
+        for (KoreanCity city : values()) {
+            if (city.getCityName().equals(cityName)) {
+                return city.getImageUrl();
+            }
+        }
+        throw new IllegalArgumentException("No such city: " + cityName);
+    }
+
+    public static List<CityResponse> getCityList() {
+        List<CityResponse> list = new ArrayList<>();
+
+        for (KoreanCity city : values()) {
+            list.add(CityResponse.builder()
+                    .cityName(city.getCityName())
+                    .imageUrl(city.getImageUrl())
+                    .build());
+        }
+
+        return list;
+    }
+
+
+}

--- a/app/src/main/java/fc/be/app/domain/space/vo/KoreanCity.java
+++ b/app/src/main/java/fc/be/app/domain/space/vo/KoreanCity.java
@@ -1,5 +1,6 @@
 package fc.be.app.domain.space.vo;
 
+import fc.be.app.domain.space.exception.SpaceException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static fc.be.app.domain.space.dto.response.CitiesResponse.CityResponse;
+import static fc.be.app.domain.space.exception.SpaceErrorCode.NO_SUCH_CITY;
 
 @Getter
 @AllArgsConstructor
@@ -40,7 +42,7 @@ public enum KoreanCity {
                 return city.getImageUrl();
             }
         }
-        throw new IllegalArgumentException("No such city: " + cityName);
+        throw new SpaceException(NO_SUCH_CITY);
     }
 
     public static List<CityResponse> getCityList() {

--- a/app/src/main/java/fc/be/app/global/util/DelimiterConverter.java
+++ b/app/src/main/java/fc/be/app/global/util/DelimiterConverter.java
@@ -1,0 +1,21 @@
+package fc.be.app.global.util;
+
+import jakarta.persistence.AttributeConverter;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DelimiterConverter implements AttributeConverter<List<String>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(List<String> attribute) {
+        return attribute != null ? String.join(DELIMITER, attribute) : null;
+    }
+
+    @Override
+    public List<String> convertToEntityAttribute(String dbData) {
+        return dbData != null ? Arrays.stream(dbData.split(DELIMITER)).toList() : null;
+    }
+}

--- a/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
+++ b/app/src/test/java/fc/be/app/domain/space/controller/SpaceControllerTest.java
@@ -104,7 +104,7 @@ class SpaceControllerTest {
     void updateSpaceByTitle() throws Exception {
         // given
         TitleUpdateRequest updateRequest = TitleUpdateRequest.builder()
-                .title("서울여행")
+                .cities(List.of("가평"))
                 .build();
 
         // when then

--- a/app/src/test/java/fc/be/app/domain/space/service/SpaceServiceTest.java
+++ b/app/src/test/java/fc/be/app/domain/space/service/SpaceServiceTest.java
@@ -158,7 +158,7 @@ class SpaceServiceTest {
         joinedMemberRepository.save(joinedMember);
 
         TitleUpdateRequest updateRequest = TitleUpdateRequest.builder()
-                .title("서울 여행")
+                .cities(List.of("가평"))
                 .build();
 
         // when
@@ -170,7 +170,7 @@ class SpaceServiceTest {
         );
 
         // then
-        assertThat(spaceResponse.title()).isEqualTo(updateRequest.title());
+        assertThat(spaceResponse.city()).isEqualTo(String.join(",", updateRequest.cities()));
     }
 
     @DisplayName("여행 스페이스의 시작일자와 종료일자에 대한 값을 업데이트를 한다.")


### PR DESCRIPTION
## 변경사항

- 여행스페이스 도시 선택 구현 
     -  도시의 데이터는 Enum 구현 
     -  도시리스트 호출 API 구현
     -  기본 타이틀 명 받는 형식에서 선택 도시항목 받도록 구현
- 여행스페이스 생성 시 타이틀 명 적용되게 구현
     -  닉네임 + "의 여행"
     
### Issue Link - #135 

