### PR TITLE
[Refactor/Bugfix] 리뷰 별점 산정방식 수정 및 버그 해결

### DIFF
--- a/app/src/main/java/fc/be/app/domain/review/dto/RatingStatisticsDTO.java
+++ b/app/src/main/java/fc/be/app/domain/review/dto/RatingStatisticsDTO.java
@@ -1,0 +1,7 @@
+package fc.be.app.domain.review.dto;
+
+public record RatingStatisticsDTO(
+        Double averageRating,
+        Long reviewCount
+) {
+}

--- a/app/src/main/java/fc/be/app/domain/review/repository/ReviewRepository.java
+++ b/app/src/main/java/fc/be/app/domain/review/repository/ReviewRepository.java
@@ -1,13 +1,12 @@
 package fc.be.app.domain.review.repository;
 
+import fc.be.app.domain.review.dto.RatingStatisticsDTO;
 import fc.be.app.domain.review.entity.Review;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
-import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r FROM Review r join fetch r.member join fetch r.place where r.member.id = :memberId")
@@ -19,6 +18,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     Review findByIdAndMemberId(Long reviewId, Long memberId);
 
-    @Query("SELECT count(r), avg(r.rating) FROM Review r WHERE r.place.id = :placeId")
-    List<Number> countAndAverageRatingByPlaceId(@Param("placeId") Integer placeId);
+    @Query("SELECT new fc.be.app.domain.review.dto.RatingStatisticsDTO(avg(r.rating), count(r)) FROM Review r WHERE r.place.id = :placeId")
+    RatingStatisticsDTO findRatingStatisticsByPlaceId(@Param("placeId") Integer placeId);
 }

--- a/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
+++ b/app/src/main/java/fc/be/app/domain/review/service/ReviewService.java
@@ -94,11 +94,11 @@ public class ReviewService {
         double googleRating = googleReviewResponse.rating();
         long googleCount = googleReviewResponse.userRatingCount();
 
-        List<Number> tripVoteResponse = responseToList(reviewRepository.countAndAverageRatingByPlaceId
+        List<Number> tripVoteResponse = responseToList(reviewRepository.findRatingStatisticsByPlaceId
                 (reviewGetRequest.placeId()));
 
-        double tripVoteRating = tripVoteResponse.getFirst().doubleValue();
-        long tripVoteCount = tripVoteResponse.getLast().longValue();
+        double tripVoteRating = (double) tripVoteResponse.getFirst();
+        long tripVoteCount = (long) tripVoteResponse.getLast();
 
         var calResult = calculateReviewAverage(googleRating, googleCount, tripVoteRating, tripVoteCount);
 
@@ -108,11 +108,11 @@ public class ReviewService {
         );
     }
 
-    private List<Number> responseToList(List<Number> response) {
-        if (response.isEmpty()) {
+    private List<Number> responseToList(RatingStatisticsDTO response) {
+        if (response.reviewCount() == 0 || response.reviewCount() == null) {
             return List.of(0.0, 0L);
         }
-        return List.of(response.getFirst().doubleValue(), response.getLast().longValue());
+        return List.of(response.averageRating(), response.reviewCount());
     }
 
     private List<Number> calculateReviewAverage(double rating1, long count1, double rating2, long count2) {

--- a/app/src/test/java/fc/be/app/domain/review/unit/ReviewServiceTest.java
+++ b/app/src/test/java/fc/be/app/domain/review/unit/ReviewServiceTest.java
@@ -6,6 +6,7 @@ import fc.be.app.domain.member.repository.MemberRepository;
 import fc.be.app.domain.place.exception.PlaceErrorCode;
 import fc.be.app.domain.place.exception.PlaceException;
 import fc.be.app.domain.place.service.PlaceService;
+import fc.be.app.domain.review.dto.RatingStatisticsDTO;
 import fc.be.app.domain.review.dto.ReviewEditResponse;
 import fc.be.app.domain.review.entity.Review;
 import fc.be.app.domain.review.exception.ReviewErrorCode;
@@ -30,7 +31,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 
 @ExtendWith(MockitoExtension.class)
 public class ReviewServiceTest implements ReviewDTOFixture {
@@ -235,8 +237,9 @@ public class ReviewServiceTest implements ReviewDTOFixture {
             given(reviewAPIService.bringRatingCount(reviewGetRequest.placeTitle(), reviewGetRequest.contentTypeId()))
                     .willReturn(APIRatingResponse);
             // Mock behavior of reviewRepository
-            given(reviewRepository.countAndAverageRatingByPlaceId(reviewGetRequest.placeId()))
-                    .willReturn(List.of(APIRatingResponse.rating(), APIRatingResponse.userRatingCount()));
+            given(reviewRepository.findRatingStatisticsByPlaceId(reviewGetRequest.placeId()))
+                    .willReturn(new RatingStatisticsDTO(APIRatingResponse.rating(),
+                            APIRatingResponse.userRatingCount().longValue()));
 
             // When
             var actual = reviewService.bringReviewRatingAndCount(reviewGetRequest);
@@ -244,7 +247,7 @@ public class ReviewServiceTest implements ReviewDTOFixture {
             // Then
             then(reviewAPIService).should().bringRatingCount
                     (reviewGetRequest.placeTitle(), reviewGetRequest.contentTypeId());
-            then(reviewRepository).should().countAndAverageRatingByPlaceId(any());
+            then(reviewRepository).should().findRatingStatisticsByPlaceId(any());
             assertNotNull(actual);
         }
 
@@ -279,8 +282,9 @@ public class ReviewServiceTest implements ReviewDTOFixture {
             given(reviewAPIService.bringRatingCount(reviewGetRequest.placeTitle(), reviewGetRequest.contentTypeId()))
                     .willReturn(new APIRatingResponse(0.0, 0));
             // Mock behavior of reviewRepository
-            given(reviewRepository.countAndAverageRatingByPlaceId(reviewGetRequest.placeId()))
-                    .willReturn(List.of(0.0, 0));
+            given(reviewRepository.findRatingStatisticsByPlaceId(reviewGetRequest.placeId()))
+                    .willReturn(new RatingStatisticsDTO(
+                            0.0, 0L));
 
             // When
             var actual = reviewService.bringReviewRatingAndCount(reviewGetRequest);
@@ -288,7 +292,7 @@ public class ReviewServiceTest implements ReviewDTOFixture {
             // Then
             then(reviewAPIService).should().bringRatingCount
                     (reviewGetRequest.placeTitle(), reviewGetRequest.contentTypeId());
-            then(reviewRepository).should().countAndAverageRatingByPlaceId(any());
+            then(reviewRepository).should().findRatingStatisticsByPlaceId(any());
             assertEquals(0.0, actual.rating());
             assertEquals(0, actual.userRatingCount());
         }

--- a/openapi/src/main/java/fc/be/openapi/google/dto/review/APIRatingResponse.java
+++ b/openapi/src/main/java/fc/be/openapi/google/dto/review/APIRatingResponse.java
@@ -10,7 +10,7 @@ public record APIRatingResponse(
     public static APIRatingResponse convertToRatingResponse(GoogleRatingResponse googleRatingResponse) {
         return new APIRatingResponse(
                 googleRatingResponse.rating(),
-                googleRatingResponse.userRatingCount()
+                googleRatingResponse.reviews().size()
         );
     }
 }

--- a/openapi/src/main/java/fc/be/openapi/google/dto/review/form/GoogleRatingResponse.java
+++ b/openapi/src/main/java/fc/be/openapi/google/dto/review/form/GoogleRatingResponse.java
@@ -1,7 +1,10 @@
 package fc.be.openapi.google.dto.review.form;
 
+import java.util.List;
+
 public record GoogleRatingResponse(
-          Double rating,
-          Integer userRatingCount
+        List<Review> reviews,
+        Double rating,
+        Integer userRatingCount
 ) {
 }

--- a/openapi/src/main/java/fc/be/openapi/google/service/GoogleReviewService.java
+++ b/openapi/src/main/java/fc/be/openapi/google/service/GoogleReviewService.java
@@ -58,7 +58,7 @@ public class GoogleReviewService implements ReviewAPIService {
     private GoogleRatingResponse searchRating(String placeId) {
         return googlePlacesClient.searchRating(
                 apiKey,
-                "rating,userRatingCount",
+                "reviews,rating,userRatingCount",
                 "ko",
                 placeId
         );

--- a/openapi/src/main/resources/review-example/rating/place_rating_12.json
+++ b/openapi/src/main/resources/review-example/rating/place_rating_12.json
@@ -1,4 +1,4 @@
 {
   "rating": 4.0,
-  "userRatingCount": 597
+  "userRatingCount": 5
 }

--- a/openapi/src/main/resources/review-example/rating/place_rating_14.json
+++ b/openapi/src/main/resources/review-example/rating/place_rating_14.json
@@ -1,4 +1,4 @@
 {
   "rating": 4.5,
-  "userRatingCount": 2318
+  "userRatingCount": 5
 }

--- a/openapi/src/main/resources/review-example/rating/place_rating_15.json
+++ b/openapi/src/main/resources/review-example/rating/place_rating_15.json
@@ -1,4 +1,4 @@
 {
   "rating": 4.2,
-  "userRatingCount": 83
+  "userRatingCount": 5
 }

--- a/openapi/src/main/resources/review-example/rating/place_rating_28.json
+++ b/openapi/src/main/resources/review-example/rating/place_rating_28.json
@@ -1,4 +1,4 @@
 {
   "rating": 4.4,
-  "userRatingCount": 2322
+  "userRatingCount": 5
 }

--- a/openapi/src/main/resources/review-example/rating/place_rating_32.json
+++ b/openapi/src/main/resources/review-example/rating/place_rating_32.json
@@ -1,4 +1,4 @@
 {
   "rating": 4.4,
-  "userRatingCount": 445
+  "userRatingCount": 5
 }

--- a/openapi/src/main/resources/review-example/rating/place_rating_38.json
+++ b/openapi/src/main/resources/review-example/rating/place_rating_38.json
@@ -1,4 +1,4 @@
 {
   "rating": 4.3,
-  "userRatingCount": 9031
+  "userRatingCount": 5
 }

--- a/openapi/src/main/resources/review-example/rating/place_rating_39.json
+++ b/openapi/src/main/resources/review-example/rating/place_rating_39.json
@@ -1,4 +1,4 @@
 {
   "rating": 4.1,
-  "userRatingCount": 2574
+  "userRatingCount": 5
 }


### PR DESCRIPTION
## 변경사항

- 기존의 `userRatingCount`는 실제 `구글에 등록된 review`를 의미하였기에 실제 API로 가져오는 `review의 개수`와 차이가 너무 컸습니다. 받아오는 방식을 실제 가져오는 `reviews`의 `size`로 카운트 하도록 수정합니다.
-  그에 따른 `example-rating.json` 파일도 수정합니다.

## 특이사항

해당 작업을 진행하던 도중 발견한 `Bug issue` : #151 가 있었습니다.
해당 메서드의 반환 DTO를 추가하였고 및 @Query문을 수정하여 버그를 해결했습니다.
추후에 JPQL 쿼리문을 리팩토링 할 수 있습니다.

###  변경사항

- `Review Repository - 별점, 카운트 구하는 메서드`에서 값을 매핑 DTO `RatingStatisticsDTO` 을 추가합니다.
- JPQL 문`RatingStatisticsDTO` 을 사용하여 해당 DTO에 평균 및 카운트 값을 담아서 리턴하도록 수정합니다.

### Issue Link - #128, #151 



