### PR TITLE
[Bugfix] S3 Presigned를 사용할 때 확장자가 포함되지 않은 버그 수정

### DIFF
--- a/app/src/main/java/fc/be/app/global/s3/service/S3Service.java
+++ b/app/src/main/java/fc/be/app/global/s3/service/S3Service.java
@@ -36,8 +36,9 @@ public class S3Service implements CreatePreSignedUrlUseCase {
         List<PreSignedElement> elements = new ArrayList<>();
 
         for (String imageName : imageNames) {
-            final String encodedFileName = createEncodedFileName();
-            GeneratePresignedUrlRequest generatePresignedUrlRequest = createGeneratePresignedUrlRequest(encodedFileName);
+            String fileExtension = extractFileExtension(imageName);
+            final String savedFileName = createEncodedFileName() + fileExtension;
+            GeneratePresignedUrlRequest generatePresignedUrlRequest = createGeneratePresignedUrlRequest(savedFileName);
             String preSignedUrl = amazonS3.generatePresignedUrl(generatePresignedUrlRequest).toString();
             elements.add(new PreSignedElement(imageName, preSignedUrl));
         }
@@ -45,13 +46,18 @@ public class S3Service implements CreatePreSignedUrlUseCase {
         return new PreSignedResponses(elements);
     }
 
+    private String extractFileExtension(String imageName) {
+        int extensionStartIndex = imageName.lastIndexOf(".");
+        return imageName.substring(extensionStartIndex);
+    }
+
     private static String createEncodedFileName() {
         String uuid = UUID.randomUUID().toString();
         return uuid + "_" + LocalDateTime.now();
     }
 
-    private GeneratePresignedUrlRequest createGeneratePresignedUrlRequest(String encodedFileName) {
-        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, encodedFileName)
+    private GeneratePresignedUrlRequest createGeneratePresignedUrlRequest(String fileName) {
+        GeneratePresignedUrlRequest generatePresignedUrlRequest = new GeneratePresignedUrlRequest(bucketName, fileName)
                 .withMethod(HttpMethod.PUT)
                 .withExpiration(getPreSignedUrlExpiration());
 


### PR DESCRIPTION
## 변경사항
- presigend 요청 후 파일을 저장할 때 확장자가 붙지 않은 상황이 발생했습니다. 확장자를 고려하지 않고 UUID와 LocalDateTime 만을 조합했기 때문에 발생한 문제였습니다.
- 확장자 추출 메서드를 추가해 수정을 했습니다.

### Issue Link - #77
