### PR TITLE
[Bugfix] Review Rating 방어 코드 추가

### DIFF
--- a/openapi/src/main/java/fc/be/openapi/google/dto/review/APIRatingResponse.java
+++ b/openapi/src/main/java/fc/be/openapi/google/dto/review/APIRatingResponse.java
@@ -8,6 +8,10 @@ public record APIRatingResponse(
 ) {
 
     public static APIRatingResponse convertToRatingResponse(GoogleRatingResponse googleRatingResponse) {
+        if(googleRatingResponse == null){
+            return new APIRatingResponse(0.0, 0);
+        }
+
         return new APIRatingResponse(
                 googleRatingResponse.rating(),
                 googleRatingResponse.reviews().size()

--- a/openapi/src/main/java/fc/be/openapi/google/service/GoogleReviewService.java
+++ b/openapi/src/main/java/fc/be/openapi/google/service/GoogleReviewService.java
@@ -33,7 +33,11 @@ public class GoogleReviewService implements ReviewAPIService {
 
     @Override
     public APIRatingResponse bringRatingCount(String textQuery, Integer contentTypeId) {
-        String placeId = bringPlaceId(textQuery).places().getFirst().id();
+        var searchPlace = bringPlaceId(textQuery);
+        if(searchPlace.places().isEmpty()){
+            return new APIRatingResponse(0.0, 0);
+        }
+        String placeId = searchPlace.places().getFirst().id();
         var response = searchRating(placeId);
         return APIRatingResponse.convertToRatingResponse(response);
     }


### PR DESCRIPTION
`#` Google Review 가 없는 경우 빈 리스트를 반환하도록 수정합니다.

## 변경사항

`Tour API` 및 `Google Places API`에서 찾을 수 없는 장소 정보에 대해
빈 리스트를 반환하는 코드를 추가합니다.

### Issue Link - #193 

