### PR TITLE
[Fix] 투표 결과보기 및 참여해야 하는 투표 조회 수정

### DIFF
--- a/app/src/main/java/fc/be/app/domain/space/entity/Space.java
+++ b/app/src/main/java/fc/be/app/domain/space/entity/Space.java
@@ -157,7 +157,7 @@ public class Space {
     }
 
     public boolean isClosed(LocalDate localDate) {
-        return this.endDate.isBefore(localDate);
+        return this.endDate != null && this.endDate.isBefore(localDate);
     }
 
 }

--- a/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/Vote.java
@@ -39,7 +39,7 @@ public class Vote {
     @Comment("투표를 만든 사람")
     private Member owner;
 
-    @OneToMany(mappedBy = "vote")
+    @OneToMany(mappedBy = "vote", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
     @Comment("후보지")
     private List<Candidate> candidates;
 

--- a/app/src/main/java/fc/be/app/domain/vote/entity/VoteResultMember.java
+++ b/app/src/main/java/fc/be/app/domain/vote/entity/VoteResultMember.java
@@ -31,6 +31,7 @@ public class VoteResultMember {
         this.id = id;
         this.memberId = memberId;
         this.voteId = voteId;
+        this.spaceId = spaceId;
     }
 
     public static VoteResultMember of(Long memberId, Long voteId, Long spaceId) {

--- a/app/src/main/java/fc/be/app/domain/vote/repository/VoteRepository.java
+++ b/app/src/main/java/fc/be/app/domain/vote/repository/VoteRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 public interface VoteRepository extends JpaRepository<Vote, Long>, VoteRepositoryCustom {
 
-    @Query("select v from Vote v where v.space.id in (select jm.space.id from JoinedMember jm where jm.member.id = :memberId) and v.space.id not in (select vrm.spaceId from VoteResultMember vrm where vrm.memberId = :memberId)")
-    List<Vote> findMemberVotes(Long memberId);
+    @Query("select v from Vote v where v.id not in (select vrm.voteId from VoteResultMember vrm where vrm.memberId = :memberId)")
+    List<Vote> findVotesNotVotedByMember(Long memberId);
 }

--- a/app/src/main/java/fc/be/app/domain/vote/repository/VoteResultMemberRepository.java
+++ b/app/src/main/java/fc/be/app/domain/vote/repository/VoteResultMemberRepository.java
@@ -2,9 +2,7 @@ package fc.be.app.domain.vote.repository;
 
 import fc.be.app.domain.vote.entity.VoteResultMember;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,16 +11,9 @@ public interface VoteResultMemberRepository extends JpaRepository<VoteResultMemb
     @Query("select vm.voteId from VoteResultMember vm where vm.memberId = :memberId and vm.spaceId = :spaceId")
     List<Long> findVoteIdsByMemberIdAndSpaceId(Long memberId, Long spaceId);
 
-    boolean existsByMemberIdAndVoteId(Long memberId, Long voteId);
-
     @Query("select vm from VoteResultMember vm where vm.memberId = :memberId and vm.voteId = :voteId")
     Optional<VoteResultMember> findByMemberIdAndVoteId(Long memberId, Long voteId);
 
     @Query("delete from VoteResultMember vm where vm.memberId = :memberId and vm.voteId = :voteId")
     void deleteByMemberIdAndVoteId(Long memberId, Long voteId);
-
-    @Modifying
-    @Query(value = "INSERT INTO VoteResultMember (memberId, voteId, spaceId) SELECT :memberId, :voteId, :spaceId WHERE NOT EXISTS (SELECT 1 FROM VoteResultMember WHERE memberId = :memberId AND voteId = :voteId)",
-            nativeQuery = true)
-    void saveIfNotExists(@Param("memberId") Long memberId, @Param("voteId") Long voteId, @Param("spaceId") Long spaceId);
 }

--- a/app/src/main/java/fc/be/app/domain/vote/service/dto/request/CandidateAddRequest.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/dto/request/CandidateAddRequest.java
@@ -9,6 +9,7 @@ public record CandidateAddRequest(
 ) {
     public record CandidateAddInfo(
             Integer placeId,
+            Integer placeTypeId,
             String tagline
     ) {
 

--- a/app/src/main/java/fc/be/app/domain/vote/service/dto/response/VoteDetailResponse.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/dto/response/VoteDetailResponse.java
@@ -1,6 +1,5 @@
 package fc.be.app.domain.vote.service.dto.response;
 
-import fc.be.app.domain.space.vo.VoteStatus;
 import fc.be.app.domain.vote.service.dto.response.vo.CandidateInfo;
 import fc.be.app.domain.vote.service.dto.response.vo.MemberProfile;
 
@@ -9,7 +8,7 @@ import java.util.List;
 public record VoteDetailResponse(
         Long id,
         String title,
-        VoteStatus voteStatus,
+        String voteStatus,
         MemberProfile createdBy,
         List<CandidateInfo> candidates
 ) {

--- a/app/src/main/java/fc/be/app/domain/vote/service/dto/response/VoteResultResponse.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/dto/response/VoteResultResponse.java
@@ -1,6 +1,5 @@
 package fc.be.app.domain.vote.service.dto.response;
 
-import fc.be.app.domain.space.vo.VoteStatus;
 import fc.be.app.domain.vote.entity.Candidate;
 import fc.be.app.domain.vote.service.dto.response.vo.MemberProfile;
 import fc.be.app.domain.vote.service.dto.response.vo.PlaceInfo;
@@ -10,7 +9,7 @@ import java.util.List;
 public record VoteResultResponse(
         Long id,
         String title,
-        VoteStatus voteStatus,
+        String voteStatus,
         MemberProfile createdBy,
         List<CandidateResultResponse> candidatesResponses
 ) {

--- a/app/src/main/java/fc/be/app/domain/vote/service/service/VoteInfoQueryService.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/service/VoteInfoQueryService.java
@@ -88,11 +88,11 @@ public class VoteInfoQueryService {
     }
 
     public VotesResponse findMemberVotes(Long memberId) {
-        List<Vote> votesNotMemberVoted = voteRepository.findMemberVotes(memberId);
+        List<Vote> votesNotMemberVoted = voteRepository.findVotesNotVotedByMember(memberId);
 
         return new VotesResponse(votesNotMemberVoted
                 .stream()
-                .filter(vote -> vote.getSpace().isClosed(LocalDate.now()))
+                .filter(vote -> !vote.getSpace().isClosed(LocalDate.now()))
                 .map(vote -> new VotesResponseElement(
                         vote.getId(),
                         vote.getTitle(),

--- a/app/src/main/java/fc/be/app/domain/vote/service/service/VoteInfoQueryService.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/service/VoteInfoQueryService.java
@@ -121,7 +121,7 @@ public class VoteInfoQueryService {
         return new VoteDetailResponse(
                 vote.getId(),
                 vote.getTitle(),
-                vote.getStatus(),
+                vote.getStatus().getDescription(),
                 MemberProfile.of(vote.getOwner()),
                 vote.getCandidates()
                         .stream()
@@ -135,6 +135,7 @@ public class VoteInfoQueryService {
                 .orElseThrow(() -> new VoteException(VOTE_NOT_FOUND));
     }
 
+    @Transactional
     public VoteResultResponse findResultByVoteId(Long voteId, Long memberId) {
         Vote vote = getByVoteId(voteId);
 
@@ -150,7 +151,7 @@ public class VoteInfoQueryService {
         return new VoteResultResponse(
                 vote.getId(),
                 vote.getTitle(),
-                vote.getStatus(),
+                vote.getStatus().getDescription(),
                 MemberProfile.of(vote.getOwner()),
                 vote.getCandidates()
                         .stream()

--- a/app/src/main/java/fc/be/app/domain/vote/service/service/VoteInfoQueryService.java
+++ b/app/src/main/java/fc/be/app/domain/vote/service/service/VoteInfoQueryService.java
@@ -6,6 +6,7 @@ import fc.be.app.domain.member.repository.MemberRepository;
 import fc.be.app.domain.space.entity.Space;
 import fc.be.app.domain.space.exception.SpaceException;
 import fc.be.app.domain.space.repository.SpaceRepository;
+import fc.be.app.domain.space.vo.VoteStatus;
 import fc.be.app.domain.vote.entity.Candidate;
 import fc.be.app.domain.vote.entity.Vote;
 import fc.be.app.domain.vote.exception.VoteException;
@@ -92,7 +93,7 @@ public class VoteInfoQueryService {
 
         return new VotesResponse(votesNotMemberVoted
                 .stream()
-                .filter(vote -> !vote.getSpace().isClosed(LocalDate.now()))
+                .filter(vote -> !vote.getSpace().isClosed(LocalDate.now()) && vote.getStatus()!= VoteStatus.DONE)
                 .map(vote -> new VotesResponseElement(
                         vote.getId(),
                         vote.getTitle(),


### PR DESCRIPTION
## 변경사항

투표 결과보기를 클릭한 유저는 더 이상 투표에 참여할 수 없습니다. 따라서 Vote_Result_Member 엔티티가 생성되어야 합나다. 
기존 코드에서 Vote_Result_Member 엔티티가 생성되지 않던 이슈를 해결하였고, `/votes/{voteId}/NotVoted` 호출시 잘못된 쿼리를 수정하였습니다.

### Issue Link - #197 


## 체크리스트
- [x] 내 코드를 스스로 검토했나요?
- [x] 핵심 기능에 대해 충분한 테스트를 수행했나요?

