### PR TITLE
[Fix] TourAPI 내 식별자 부재에 대한 처리 로직 추가

### DIFF
--- a/app/src/main/java/fc/be/app/domain/member/controller/dto/response/MyPlacesResponse.java
+++ b/app/src/main/java/fc/be/app/domain/member/controller/dto/response/MyPlacesResponse.java
@@ -39,7 +39,7 @@ public record MyPlacesResponse(
                 String phone,
                 Integer areaCode,
                 Integer sigunguCode,
-                Integer zipCode,
+                String zipCode,
                 Double latitude,
                 Double longitude
         ) {

--- a/app/src/main/java/fc/be/app/domain/place/Location.java
+++ b/app/src/main/java/fc/be/app/domain/place/Location.java
@@ -26,7 +26,7 @@ public class Location {
     private Integer sigunguCode;
 
     @Comment("우편번호")
-    private Integer zipCode;
+    private String zipCode;
 
     @Comment("위도")
     private Double latitude;
@@ -35,7 +35,7 @@ public class Location {
     private Double longitude;
 
     @Builder
-    public Location(String address, String addressDetail, String phone, Integer areaCode, Integer sigunguCode, Integer zipCode, Double latitude, Double longitude) {
+    public Location(String address, String addressDetail, String phone, Integer areaCode, Integer sigunguCode, String zipCode, Double latitude, Double longitude) {
         this.address = address;
         this.addressDetail = addressDetail;
         this.phone = phone;

--- a/app/src/main/java/fc/be/app/domain/place/dto/PlaceInfoGetResponse.java
+++ b/app/src/main/java/fc/be/app/domain/place/dto/PlaceInfoGetResponse.java
@@ -37,7 +37,7 @@ public record PlaceInfoGetResponse(PlaceDTO place) {
             AccommodationDTO.class, Accommodation.class,
             FacilityDTO.class, Facility.class,
             FestivalDTO.class, Festival.class,
-            LeportsDTO.class, Festival.class,
+            LeportsDTO.class, Leports.class,
             RestaurantDTO.class, Restaurant.class,
             ShopDTO.class, Shop.class,
             SpotDTO.class, Spot.class

--- a/app/src/test/java/fc/be/app/domain/review/unit/ReviewFixture.java
+++ b/app/src/test/java/fc/be/app/domain/review/unit/ReviewFixture.java
@@ -38,7 +38,7 @@ public interface ReviewFixture {
                         .phone("")
                         .areaCode(1)
                         .sigunguCode(18)
-                        .zipCode(5838)
+                        .zipCode("5838")
                         .latitude(37.4776672007)
                         .longitude(127.1249768726)
                         .build())

--- a/openapi/src/main/java/fc/be/openapi/tourapi/dto/mapper/AreaBasedSyncMapper.java
+++ b/openapi/src/main/java/fc/be/openapi/tourapi/dto/mapper/AreaBasedSyncMapper.java
@@ -23,7 +23,7 @@ public class AreaBasedSyncMapper implements TourAPIMapper<PlaceDTO, AreaBasedSyn
                         .phone(item.tel())
                         .areaCode(Integer.parseInt(item.areacode()))
                         .sigunguCode(Integer.parseInt(item.sigungucode()))
-                        .zipCode(Integer.parseInt(item.zipcode()))
+                        .zipCode(item.zipcode())
                         .latitude(Double.parseDouble(item.mapy()))
                         .longitude(Double.parseDouble(item.mapx()))
                         .build())

--- a/openapi/src/main/java/fc/be/openapi/tourapi/dto/mapper/DetailCommonMapper.java
+++ b/openapi/src/main/java/fc/be/openapi/tourapi/dto/mapper/DetailCommonMapper.java
@@ -25,7 +25,7 @@ public class DetailCommonMapper implements TourAPIMapper<PlaceDTO, DetailCommon1
                         .phone(item.tel())
                         .areaCode(Integer.parseInt(item.areacode()))
                         .sigunguCode(Integer.parseInt(item.sigungucode()))
-                        .zipCode(Integer.parseInt(item.zipcode()))
+                        .zipCode(item.zipcode())
                         .latitude(Double.parseDouble(item.mapy()))
                         .longitude(Double.parseDouble(item.mapx()))
                         .build())

--- a/openapi/src/main/java/fc/be/openapi/tourapi/dto/response/bone/LocationDTO.java
+++ b/openapi/src/main/java/fc/be/openapi/tourapi/dto/response/bone/LocationDTO.java
@@ -15,7 +15,7 @@ public class LocationDTO {
     private String phone;
     private Integer areaCode;
     private Integer sigunguCode;
-    private Integer zipCode;
+    private String zipCode;
     private Double latitude;
     private Double longitude;
 }

--- a/openapi/src/main/java/fc/be/openapi/tourapi/tools/DomainConverter.java
+++ b/openapi/src/main/java/fc/be/openapi/tourapi/tools/DomainConverter.java
@@ -70,6 +70,10 @@ public class DomainConverter {
         List<PlaceDTO> result = new ArrayList<>();
 
         for (var item : items) {
+            if (checkIdentifierCodesInvalid(item.contentid(), item.contenttypeid(), item.areacode(), item.sigungucode())) {
+                continue;
+            }
+
             int itemContentTypeId = contentTypeId == 0 ? Integer.parseInt(item.contenttypeid()) : contentTypeId;
             var itemClass = convertPlaceToChildDomain(itemContentTypeId);
             result.add(generateAndCastItem(item, areaBasedSyncMapper::generate, itemClass));
@@ -106,6 +110,10 @@ public class DomainConverter {
         List<PlaceDTO> result = new ArrayList<>();
 
         for (var item : items) {
+            if (checkIdentifierCodesInvalid(item.contentid(), item.contenttypeid(), item.areacode(), item.sigungucode())) {
+                continue;
+            }
+
             int itemContentTypeId = contentTypeId == 0 ? Integer.parseInt(item.contenttypeid()) : contentTypeId;
             if (ContentTypeId.contains(itemContentTypeId)) {
                 var itemClass = convertPlaceToChildDomain(itemContentTypeId);
@@ -129,5 +137,14 @@ public class DomainConverter {
         }
     }
 
+    private boolean checkIdentifierCodesInvalid(String... values) {
+        for (var value : values) {
+            if (value == null || value.isBlank()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
 }


### PR DESCRIPTION
## 변경사항

장소 목록 중에서 contentId, areaCode, sigunguCode 가 없는 데이터에 대한 처리 로직이 구현되었습니다.
우편번호(zipCode) 가 Integer -> String 으로 변경되었습니다

BREAK CHANGES: place 엔티티 내 zipCode 타입이 변경되어 운영환경 DB에 작업이 필요합니다. api 문서 최신화 필수

### Issue Link - #215


## 체크리스트

- [x] 식별자 값에 이상이 있으면 해당 데이터는 제외하고 서빙하나요?
- [x] 가공 과정(`DomainConverter`)에서의 문제가 해결되었나요?
- [x] 충분한 검증을 수행했나요?

## 참고
![스크린샷 2024-01-28 020719](https://github.com/Strong-Potato/TripVote-BE/assets/26517061/43d2a9fa-1a7a-4e02-bb8d-fa961007b529)
![스크린샷 2024-01-28 020741](https://github.com/Strong-Potato/TripVote-BE/assets/26517061/7bf0b828-c330-41ce-8ad1-bc312cf6c50a)
