### PR TITLE
[Bugfix] originalText null 방지 코드 추가

### DIFF
--- a/openapi/src/main/java/fc/be/openapi/google/dto/review/APIReviewResponse.java
+++ b/openapi/src/main/java/fc/be/openapi/google/dto/review/APIReviewResponse.java
@@ -17,7 +17,7 @@ public record APIReviewResponse(
                     review.authorAttribution().photoUri(),
                     review.rating(),
                     review.publishTime(),
-                    review.originalText().text(),
+                    (review.originalText() == null) ? "" : review.originalText().text(),
                     true,
                     List.of()
             );


### PR DESCRIPTION
`#` Google Text가 Null일 경우, 공백으로 대체합니다.

 리뷰는 존재하지만 해당 리뷰의 본문이 공백인 경우, NPE가 발생하였습니다.
해당 사항에 대한 `Bugfix`를 진행합니다.

## 변경사항

`Review`를 변환하는 도중에서 본문이 없는 리뷰에 대한 `NPE` 방지 코드를 작성합니다.

### Issue Link - #218 


## 특이사항

파악한 바로는 구글 리뷰 작성 정책상, 공백으로 기재할 수 있는 항목은 본문 하나인 것 같아 해당 케이스만 고려했습니다.

## 참고
![리뷰작성](https://github.com/Strong-Potato/TripVote-BE/assets/71982555/6eb9c69e-9bfd-48b0-9d15-50d253078858)



